### PR TITLE
Add demo page for approved email list API

### DIFF
--- a/BlazorWP/Layout/NavMenu.razor
+++ b/BlazorWP/Layout/NavMenu.razor
@@ -75,6 +75,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="approved-email-demo">
+                <span class="bi bi-envelope-fill" aria-hidden="true"></span> Approved Emails
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="media">
                 <span class="bi bi-image" aria-hidden="true"></span> Media Library
             </NavLink>

--- a/BlazorWP/Pages/ApprovedEmailDemo.razor
+++ b/BlazorWP/Pages/ApprovedEmailDemo.razor
@@ -1,0 +1,126 @@
+@page "/approved-email-demo"
+@using WordPressPCL
+@using System.Net.Http.Json
+@using System.Text.Json
+@inject LocalStorageJsInterop StorageJs
+@inject AuthMessageHandler AuthHandler
+
+<PageTitle>Approved Email Demo</PageTitle>
+
+<h1>Approved Email List</h1>
+
+@if (client == null)
+{
+    <p>No WordPress endpoint verified. Visit <NavLink href="/">Home</NavLink> first.</p>
+}
+else
+{
+    <div class="mb-3 d-flex gap-2">
+        <input class="form-control" placeholder="email@example.com" @bind="newEmail" />
+        <button class="btn btn-primary" @onclick="AddEmailAsync">Add</button>
+    </div>
+    @if (!string.IsNullOrEmpty(status))
+    {
+        <p>@status</p>
+    }
+    @if (emails == null)
+    {
+        <p><em>Loading...</em></p>
+    }
+    else if (emails.Count == 0)
+    {
+        <p>No approved emails found.</p>
+    }
+    else
+    {
+        <table class="table table-sm">
+            <thead>
+                <tr>
+                    <th>Email</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var e in emails)
+                {
+                    <tr>
+                        <td>@e</td>
+                        <td>
+                            <button class="btn btn-danger btn-sm" @onclick="() => RemoveEmailAsync(e)">Remove</button>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+}
+
+@code {
+    private WordPressClient? client;
+    private HttpClient? httpClient;
+    private List<string>? emails;
+    private string newEmail = string.Empty;
+    private string? status;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            return;
+        }
+        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
+        httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };
+        client = new WordPressClient(httpClient);
+        await LoadEmailsAsync();
+    }
+
+    private async Task LoadEmailsAsync()
+    {
+        if (httpClient == null) return;
+        try
+        {
+            var list = await httpClient.GetFromJsonAsync<List<string>>("approved-email-list/v1/approved-emails");
+            emails = list ?? new();
+        }
+        catch (Exception ex)
+        {
+            status = $"Error: {ex.Message}";
+            emails = new();
+        }
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task AddEmailAsync()
+    {
+        if (httpClient == null || string.IsNullOrWhiteSpace(newEmail)) return;
+        status = null;
+        try
+        {
+            var resp = await httpClient.PostAsJsonAsync("approved-email-list/v1/approved-emails", new { email = newEmail });
+            resp.EnsureSuccessStatusCode();
+            newEmail = string.Empty;
+            await LoadEmailsAsync();
+        }
+        catch (Exception ex)
+        {
+            status = $"Error: {ex.Message}";
+        }
+    }
+
+    private async Task RemoveEmailAsync(string email)
+    {
+        if (httpClient == null) return;
+        status = null;
+        try
+        {
+            var resp = await httpClient.DeleteAsync($"approved-email-list/v1/approved-emails/{Uri.EscapeDataString(email)}");
+            resp.EnsureSuccessStatusCode();
+            await LoadEmailsAsync();
+        }
+        catch (Exception ex)
+        {
+            status = $"Error: {ex.Message}";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ApprovedEmailDemo` razor page demonstrating approved-email-list-manager API
- link Approved Emails page from the sidebar menu

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688abfca41308322980e7144f1c51e82