### PR TITLE
Add invitation token demo

### DIFF
--- a/BlazorWP/Layout/NavMenu.razor
+++ b/BlazorWP/Layout/NavMenu.razor
@@ -79,6 +79,11 @@
                 <span class="bi bi-image" aria-hidden="true"></span> Media Library
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="invite-token">
+                <span class="bi bi-ticket-perforated" aria-hidden="true"></span> Invite Token
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/BlazorWP/Pages/InviteToken.razor
+++ b/BlazorWP/Pages/InviteToken.razor
@@ -1,0 +1,87 @@
+@page "/invite-token"
+@using System.Net.Http.Json
+@inject LocalStorageJsInterop StorageJs
+@inject AuthMessageHandler AuthHandler
+
+<PageTitle>Invite Token</PageTitle>
+
+<h1>Invite Token</h1>
+
+@if (httpClient == null)
+{
+    <p>Please verify a WordPress endpoint on the <NavLink href="/">Home</NavLink> page first.</p>
+}
+else
+{
+    <button class="btn btn-primary" @onclick="GenerateTokenAsync">Generate Token</button>
+
+    @if (response != null)
+    {
+        <div class="mt-3">
+            <strong>Token:</strong>
+            <pre class="json-view">@responseJson</pre>
+        </div>
+    }
+    @if (!string.IsNullOrEmpty(error))
+    {
+        <p class="text-danger mt-2">@error</p>
+    }
+}
+
+@code {
+    private HttpClient? httpClient;
+    private InviteResponse? response;
+    private string? responseJson;
+    private string? error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            return;
+        }
+        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
+        httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };
+    }
+
+    private async Task GenerateTokenAsync()
+    {
+        if (httpClient == null) return;
+        response = null;
+        error = null;
+        responseJson = null;
+        try
+        {
+            using var resp = await httpClient.PostAsync("invite/v1/token", null);
+            var json = await resp.Content.ReadAsStringAsync();
+            if (resp.IsSuccessStatusCode)
+            {
+                try
+                {
+                    response = JsonSerializer.Deserialize<InviteResponse>(json);
+                    responseJson = JsonSerializer.Serialize(response, new JsonSerializerOptions { WriteIndented = true });
+                }
+                catch
+                {
+                    responseJson = json;
+                }
+            }
+            else
+            {
+                error = json;
+            }
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+    }
+
+    private class InviteResponse
+    {
+        public string? Token { get; set; }
+        public int ExpiresIn { get; set; }
+        public string? IssuedAt { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add InviteToken Razor page that posts to `/invite/v1/token`
- link the new page from sidebar

## Testing
- ❌ `dotnet build` *(dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688ace9f3ae48322964b11cd4500046d