### PR TITLE
Handle DELETE email parameter from JSON

### DIFF
--- a/wp-content/mu-plugins/approved-email-list-manager-api.php
+++ b/wp-content/mu-plugins/approved-email-list-manager-api.php
@@ -122,7 +122,21 @@ class Approved_Email_List_Manager_API {
      * Remove an approved email
      */
     public function remove_email( $request ) {
-        $email  = strtolower( $request->get_param( 'email' ) );
+        $email = $request->get_param( 'email' );
+
+        // WP doesn't parse JSON bodies for DELETE by default, so check manually.
+        if ( empty( $email ) ) {
+            $json = $request->get_json_params();
+            if ( isset( $json['email'] ) ) {
+                $email = $json['email'];
+            }
+        }
+
+        if ( empty( $email ) ) {
+            return new WP_Error( 'missing_email', 'Email parameter is required.', array( 'status' => 400 ) );
+        }
+
+        $email  = strtolower( $email );
         $emails = get_option( self::OPTION_NAME, array() );
 
         if ( ! in_array( $email, $emails, true ) ) {


### PR DESCRIPTION
## Summary
- handle JSON body parameters for DELETE in approved-email-list API

## Testing
- `php -l wp-content/mu-plugins/approved-email-list-manager-api.php`
- `composer validate --no-check-all --strict`
- `php -l wp-content/mu-plugins/invite-jwt.php`
- `php -l wp-content/mu-plugins/social-oauth-login.php`
- `php -l wp-content/mu-plugins/pdf-preview-stub.php`


------
https://chatgpt.com/codex/tasks/task_e_688b2547f16483229e808352068d31da