### PR TITLE
Fix email parameter decoding

### DIFF
--- a/wp-content/mu-plugins/approved-email-list-manager-api.php
+++ b/wp-content/mu-plugins/approved-email-list-manager-api.php
@@ -65,8 +65,9 @@ class Approved_Email_List_Manager_API {
             'args'                => array(
                 'email' => array(
                     'required'          => true,
+                    'sanitize_callback' => 'rawurldecode',
                     'validate_callback' => function( $param ) {
-                        return is_email( $param );
+                        return (bool) is_email( $param );
                     },
                 ),
             ),
@@ -78,8 +79,9 @@ class Approved_Email_List_Manager_API {
             'permission_callback' => array( $this, 'permissions_check' ),
             'args'                => array(
                 'email' => array(
+                    'sanitize_callback' => 'rawurldecode',
                     'validate_callback' => function( $param ) {
-                        return is_email( $param );
+                        return (bool) is_email( $param );
                     },
                 ),
             ),


### PR DESCRIPTION
## Summary
- decode URL-encoded addresses using `sanitize_callback` and ensure boolean validation

## Testing
- `php -l wp-content/mu-plugins/approved-email-list-manager-api.php`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688b2f2c9e108322946ec5242b605a0e