### PR TITLE
Fix OAuth login error style

### DIFF
--- a/wp-content/mu-plugins/social-oauth-login.php
+++ b/wp-content/mu-plugins/social-oauth-login.php
@@ -4,7 +4,7 @@
  * Description: Enables Google and GitHub OAuth login & registration on WP login screens,
  *              styled with Bootstrap via esm.sh and custom brand colors, with HEREDOC
  *              separators. Includes enhanced error handling and account linking.
- * Version:     1.5.7
+ * Version:     1.5.8
  * Author:      Your Name
  */
 
@@ -23,7 +23,7 @@ function sol_redirect_with_error($msg) {
 add_filter('login_errors', function($errors) {
     if (! empty($_GET['sol_err'])) {
         $err_msg = sanitize_text_field(wp_unslash($_GET['sol_err']));
-        $errors .= '<p class="sol-error">' . esc_html($err_msg) . '</p>';
+        $errors .= '<div id="login_error" class="notice notice-error"><p>' . esc_html($err_msg) . '</p></div>';
     }
     return $errors;
 });
@@ -34,7 +34,7 @@ add_filter('login_errors', function($errors) {
 add_filter('login_message', function($message) {
     if (! empty($_GET['sol_err'])) {
         $err_msg = sanitize_text_field(wp_unslash($_GET['sol_err']));
-        $message = '<p class="sol-error">' . esc_html($err_msg) . '</p>' . $message;
+        $message = '<div id="login_error" class="notice notice-error"><p>' . esc_html($err_msg) . '</p></div>' . $message;
     }
     return $message;
 }, 5);


### PR DESCRIPTION
## Summary
- ensure OAuth failures show the same login error markup as core
- bump Social OAuth Login version

## Testing
- `php -l wp-content/mu-plugins/social-oauth-login.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_688bfeb58d4083229fa6a7c521962c49