### PR TITLE
feat: add wordpress url setting

### DIFF
--- a/BlazorWP/Layout/MainLayout.razor
+++ b/BlazorWP/Layout/MainLayout.razor
@@ -42,6 +42,8 @@
     private WpNonceJsInterop NonceJs { get; set; } = default!;
     [Inject]
     private WpEndpointSyncJsInterop EndpointSyncJs { get; set; } = default!;
+    [Inject]
+    private IConfiguration Config { get; set; } = default!;
 
     private string? currentEndpoint;
     private string? currentUsername;
@@ -53,6 +55,15 @@
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            var configEndpoint = Config["WordPress:Url"];
+            if (!string.IsNullOrEmpty(configEndpoint))
+            {
+                endpoint = configEndpoint;
+                await StorageJs.SetItemAsync("wpEndpoint", endpoint);
+            }
+        }
         string? username = null;
         if (!string.IsNullOrEmpty(endpoint))
         {

--- a/BlazorWP/Pages/Home.razor
+++ b/BlazorWP/Pages/Home.razor
@@ -186,12 +186,23 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
     private WpEndpointSyncJsInterop EndpointSyncJs { get; set; } = default!;
     [Inject]
     private IJSRuntime JS { get; set; } = default!;
+    [Inject]
+    private IConfiguration Config { get; set; } = default!;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
             verifiedEndpoint = await StorageJs.GetItemAsync("wpEndpoint");
+            if (string.IsNullOrEmpty(verifiedEndpoint))
+            {
+                var configEndpoint = Config["WordPress:Url"];
+                if (!string.IsNullOrEmpty(configEndpoint))
+                {
+                    verifiedEndpoint = configEndpoint;
+                    await StorageJs.SetItemAsync("wpEndpoint", verifiedEndpoint);
+                }
+            }
             userUrl = verifiedEndpoint;
             if (!string.IsNullOrEmpty(verifiedEndpoint))
             {

--- a/BlazorWP/_Imports.razor
+++ b/BlazorWP/_Imports.razor
@@ -17,3 +17,4 @@
 @using PanoramicData.Blazor.Arguments
 @using BlazorWP.Data
 @using AntDesign
+@using Microsoft.Extensions.Configuration

--- a/BlazorWP/appsettings.Development.json
+++ b/BlazorWP/appsettings.Development.json
@@ -9,5 +9,8 @@
         }
       }
     }
+  },
+  "WordPress": {
+    "Url": "https://yasuaki.com"
   }
 }

--- a/BlazorWP/appsettings.json
+++ b/BlazorWP/appsettings.json
@@ -9,6 +9,9 @@
     "Line": {
       "ClientId": "2007382036"
     }
+  },
+  "WordPress": {
+    "Url": "https://yasuaki.com"
   }
 }
 


### PR DESCRIPTION
## Summary
- allow configuring default WordPress endpoint via appsettings
- seed local storage with the configured WordPress URL in main layout and home page

## Testing
- `dotnet build BlazorWP/BlazorWP.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689301f9a85c8322afcdd1c87918f419