### PR TITLE
Add WordPress users page with sidebar navigation

### DIFF
--- a/BlazorWP/Layout/NavMenu.razor
+++ b/BlazorWP/Layout/NavMenu.razor
@@ -89,6 +89,11 @@
                 <span class="bi bi-ticket-perforated" aria-hidden="true"></span> Invite Token
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="wp-users">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> WP Users
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/BlazorWP/Pages/WpUsers.razor
+++ b/BlazorWP/Pages/WpUsers.razor
@@ -1,0 +1,91 @@
+@page "/wp-users"
+@using WordPressPCL
+@using WordPressPCL.Models
+@inject LocalStorageJsInterop StorageJs
+@inject JwtService JwtService
+
+<PageTitle>WordPress Users</PageTitle>
+
+@if (client == null)
+{
+    <p>No WordPress endpoint verified. Visit <NavLink href="/">Home</NavLink> first.</p>
+}
+else if (users == null && string.IsNullOrEmpty(error))
+{
+    <p><em>Loading...</em></p>
+}
+else if (!string.IsNullOrEmpty(error))
+{
+    <p class="text-danger">Error: @error</p>
+}
+else
+{
+    <div class="row">
+        <div class="col-3">
+            <ul class="list-group">
+                @foreach (var u in users)
+                {
+                    <li class="list-group-item @GetActiveClass(u)"
+                        @onclick="() => SelectUser(u)">
+                        @u.Name
+                    </li>
+                }
+            </ul>
+        </div>
+        <div class="col">
+            @if (selectedUser != null)
+            {
+                <h3>@selectedUser.Name</h3>
+                <p><strong>Email:</strong> @selectedUser.Email</p>
+                <p><strong>Slug:</strong> @selectedUser.Slug</p>
+                <p><strong>Link:</strong> <a href="@selectedUser.Link" target="_blank">@selectedUser.Link</a></p>
+            }
+            else
+            {
+                <p>Select a user from the sidebar.</p>
+            }
+        </div>
+    </div>
+}
+
+@code {
+    private WordPressClient? client;
+    private IList<User>? users;
+    private User? selectedUser;
+    private string? error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            return;
+        }
+
+        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
+        client = new WordPressClient(baseUrl);
+
+        var token = await JwtService.GetCurrentJwtAsync();
+        if (!string.IsNullOrEmpty(token))
+        {
+            client.Auth.SetJWToken(token);
+        }
+
+        try
+        {
+            users = await client.Users.GetAllAsync();
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+    }
+
+    private void SelectUser(User user)
+    {
+        selectedUser = user;
+    }
+
+    private string GetActiveClass(User user) => selectedUser?.Id == user.Id ? "active" : string.Empty;
+}
+


### PR DESCRIPTION
## Summary
- add `/wp-users` page that retrieves WordPress users via WordPressPCL and displays details alongside a user list sidebar
- link the new page from the main navigation menu

## Testing
- `dotnet build` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6893051891948322969dcf6287adfd76