### PR TITLE
Ensure TinyMCE images use source URL

### DIFF
--- a/BlazorWP/wwwroot/js/tinyMceConfig.js
+++ b/BlazorWP/wwwroot/js/tinyMceConfig.js
@@ -33,7 +33,18 @@ window.myTinyMceConfig = {
           const text = (i.title && i.title.rendered) ? i.title.rendered : 'Download PDF';
           desc = encodeURIComponent(`<a href="${i.source_url}" target="_blank">${text}</a>`);
         } else {
-          desc = encodeURIComponent(i.description && i.description.rendered ? i.description.rendered : `<img src="${i.source_url}" />`);
+          let src = i.source_url;
+          try {
+            const srcUrl = new URL(src);
+            const mediaSource = getMediaSource();
+            if (mediaSource) {
+              const mediaOrigin = new URL(mediaSource).origin;
+              if (srcUrl.origin === mediaOrigin) {
+                src = srcUrl.pathname + srcUrl.search + srcUrl.hash;
+              }
+            }
+          } catch (err) { }
+          desc = encodeURIComponent(`<img src="${src}" />`);
         }
         return `<img src="${thumb}" data-desc="${desc}" style="width:100px;height:100px;object-fit:cover;margin:4px;cursor:pointer;" />`;
       }


### PR DESCRIPTION
## Summary
- Ensure TinyMCE's media dialog inserts images referencing their `source_url` (using root-relative paths when possible)

## Testing
- `dotnet build BlazorWP/BlazorWP.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_6893f5f0b5688322b41fbcf58a00c7f0