### PR TITLE
feat: add nav link for WP API proxy demo

### DIFF
--- a/BlazorWP/Layout/NavMenu.razor
+++ b/BlazorWP/Layout/NavMenu.razor
@@ -95,6 +95,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="wp-api-proxy-demo">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> WP API Proxy Demo
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="diagnostics">
                 <span class="bi bi-gear-fill-nav-menu" aria-hidden="true"></span> Diagnostics
             </NavLink>


### PR DESCRIPTION
## Summary
- add navigation menu item linking to the new WP API proxy demo page

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894397c3efc83228ec54114fdbd215d