### PR TITLE
Refactor WpApiProxyDemo script to avoid string issues

### DIFF
--- a/BlazorWP/Pages/WpApiProxyDemo.razor
+++ b/BlazorWP/Pages/WpApiProxyDemo.razor
@@ -44,12 +44,16 @@
         var url = endpoint.TrimEnd('/') + "/wp-json/wp/v2/users/me";
         try
         {
-            var script = @$"fetch('{url}')
-                .then(async res => {{
-                    const text = await res.text();
-                    return res.ok ? text : res.status + ' ' + res.statusText + ': ' + text;
-                }})
-                .catch(err => 'Error: ' + err)";
+            var scriptLines = new[]
+            {
+                $"fetch('{url}')",
+                ".then(async res => {",
+                "    const text = await res.text();",
+                "    return res.ok ? text : res.status + ' ' + res.statusText + ': ' + text;",
+                "})",
+                ".catch(err => 'Error: ' + err)"
+            };
+            var script = string.Join("\n", scriptLines);
             jsResult = await JS.InvokeAsync<string>("eval", script);
         }
         catch (Exception ex)
@@ -75,7 +79,7 @@
             {
                 client.Auth.SetJWToken(token);
             }
-            var me = await client.Users.GetCurrentUser();
+            var me = await client.Users.GetCurrentUserAsync();
             proxyResult = JsonSerializer.Serialize(me, new JsonSerializerOptions { WriteIndented = true });
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- simplify JavaScript snippet construction in `WpApiProxyDemo.razor`
- call `GetCurrentUserAsync` from WordPress client

## Testing
- `dotnet build` *(fails: command not found)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: CONNECT tunnel failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68943f31cbdc8322bda48422f5cb43ca