### PR TITLE
Add WordPress API proxy endpoint and JS helper

### DIFF
--- a/BlazorWP/BlazorWP.Server/BlazorWP.Server.csproj
+++ b/BlazorWP/BlazorWP.Server/BlazorWP.Server.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../BlazorWP.csproj" />
+  </ItemGroup>
+</Project>

--- a/BlazorWP/BlazorWP.Server/Program.cs
+++ b/BlazorWP/BlazorWP.Server/Program.cs
@@ -1,0 +1,73 @@
+using System.Net.Http;
+using Microsoft.AspNetCore.Http;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddHttpClient();
+
+var app = builder.Build();
+
+app.UseBlazorFrameworkFiles();
+app.UseStaticFiles();
+
+app.Map("/api/wp-proxy", async (HttpContext context, IHttpClientFactory httpClientFactory, IConfiguration config) =>
+{
+    var path = context.Request.Query["path"].ToString();
+    if (string.IsNullOrEmpty(path))
+    {
+        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+        await context.Response.WriteAsync("Missing path");
+        return;
+    }
+
+    var baseUrl = config["WordPress:BaseUrl"];
+    if (string.IsNullOrEmpty(baseUrl))
+    {
+        context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+        await context.Response.WriteAsync("WordPress base URL not configured.");
+        return;
+    }
+
+    var targetUri = new Uri(new Uri(baseUrl), path);
+    var requestMessage = new HttpRequestMessage(new HttpMethod(context.Request.Method), targetUri);
+
+    if (context.Request.Headers.TryGetValue("Authorization", out var auth))
+    {
+        requestMessage.Headers.TryAddWithoutValidation("Authorization", auth.ToArray());
+    }
+    if (context.Request.Headers.TryGetValue("X-WP-Nonce", out var nonce))
+    {
+        requestMessage.Headers.TryAddWithoutValidation("X-WP-Nonce", nonce.ToArray());
+    }
+
+    if (!HttpMethods.IsGet(context.Request.Method) && !HttpMethods.IsHead(context.Request.Method))
+    {
+        requestMessage.Content = new StreamContent(context.Request.Body);
+        foreach (var header in context.Request.Headers)
+        {
+            if (header.Key.StartsWith("Content-", StringComparison.OrdinalIgnoreCase))
+            {
+                requestMessage.Content.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
+            }
+        }
+    }
+
+    var client = httpClientFactory.CreateClient();
+    using var responseMessage = await client.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, context.RequestAborted);
+
+    context.Response.StatusCode = (int)responseMessage.StatusCode;
+    foreach (var header in responseMessage.Headers)
+    {
+        context.Response.Headers[header.Key] = header.Value.ToArray();
+    }
+    foreach (var header in responseMessage.Content.Headers)
+    {
+        context.Response.Headers[header.Key] = header.Value.ToArray();
+    }
+
+    await responseMessage.Content.CopyToAsync(context.Response.Body);
+});
+
+app.MapFallbackToFile("index.html");
+
+app.Run();

--- a/BlazorWP/BlazorWP.Server/appsettings.json
+++ b/BlazorWP/BlazorWP.Server/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "WordPress": {
+    "BaseUrl": "https://example.com"
+  }
+}

--- a/BlazorWP/BlazorWP.sln
+++ b/BlazorWP/BlazorWP.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorWP", "BlazorWP.csproj", "{DB1C0860-F07D-47F6-0828-CF0581B62AC3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorWP.Server", "BlazorWP.Server/BlazorWP.Server.csproj", "{8D848D82-E832-40B6-9772-9725E79936BF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,9 +14,13 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DB1C0860-F07D-47F6-0828-CF0581B62AC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DB1C0860-F07D-47F6-0828-CF0581B62AC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DB1C0860-F07D-47F6-0828-CF0581B62AC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DB1C0860-F07D-47F6-0828-CF0581B62AC3}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {DB1C0860-F07D-47F6-0828-CF0581B62AC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {DB1C0860-F07D-47F6-0828-CF0581B62AC3}.Release|Any CPU.Build.0 = Release|Any CPU
+                {8D848D82-E832-40B6-9772-9725E79936BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {8D848D82-E832-40B6-9772-9725E79936BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {8D848D82-E832-40B6-9772-9725E79936BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {8D848D82-E832-40B6-9772-9725E79936BF}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/BlazorWP/Pages/WpApiProxyDemo.razor
+++ b/BlazorWP/Pages/WpApiProxyDemo.razor
@@ -1,9 +1,6 @@
 @page "/wp-api-proxy-demo"
-@using WordPressPCL
 @inject IJSRuntime JS
-@inject JwtService JwtService
 @inject LocalStorageJsInterop StorageJs
-@inject AuthMessageHandler AuthHandler
 
 <PageTitle>WP API Proxy Demo</PageTitle>
 
@@ -64,23 +61,9 @@
 
     private async Task CallViaProxyAsync()
     {
-        if (string.IsNullOrEmpty(endpoint))
-        {
-            proxyResult = "No endpoint configured.";
-            return;
-        }
-        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        var httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };
-        var client = new WordPressClient(httpClient);
         try
         {
-            var token = await JwtService.GetCurrentJwtAsync();
-            if (!string.IsNullOrEmpty(token))
-            {
-                client.Auth.SetJWToken(token);
-            }
-            var me = await client.Users.GetCurrentUserAsync();
-            proxyResult = JsonSerializer.Serialize(me, new JsonSerializerOptions { WriteIndented = true });
+            proxyResult = await JS.InvokeAsync<string>("fetchProxy", "/wp-json/wp/v2/users/me");
         }
         catch (Exception ex)
         {

--- a/BlazorWP/wwwroot/index.html
+++ b/BlazorWP/wwwroot/index.html
@@ -35,6 +35,7 @@
     <script src="lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="js/tinyMceConfig.js"></script>
+    <script src="js/wpApiProxy.js"></script>
 </body>
 
 </html>

--- a/BlazorWP/wwwroot/js/wpApiProxy.js
+++ b/BlazorWP/wwwroot/js/wpApiProxy.js
@@ -1,0 +1,9 @@
+window.fetchProxy = async function(path) {
+    try {
+        const res = await fetch('/api/wp-proxy?path=' + encodeURIComponent(path));
+        const text = await res.text();
+        return res.ok ? text : res.status + ' ' + res.statusText + ': ' + text;
+    } catch (err) {
+        return 'Error: ' + err;
+    }
+};


### PR DESCRIPTION
## Summary
- add minimal API server with `/api/wp-proxy` to forward WordPress REST requests
- introduce `wpApiProxy.js` helper for browser calls
- update proxy demo page to use JS helper and register script

## Testing
- `dotnet build BlazorWP/BlazorWP.sln` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68944590fbc48322af5a1b2e0eadb123