### PR TITLE
Standardize JS auth headers with shared apiFetch and TinyMCE refactor

### DIFF
--- a/BlazorWP/wwwroot/index.html
+++ b/BlazorWP/wwwroot/index.html
@@ -34,6 +34,7 @@
     </div>
     <script src="lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
+    <script type="module" src="js/apiFetch.js"></script>
     <script src="js/tinyMceConfig.js"></script>
 </body>
 

--- a/BlazorWP/wwwroot/js/apiFetch.js
+++ b/BlazorWP/wwwroot/js/apiFetch.js
@@ -1,0 +1,26 @@
+import { getNonce } from './wpNonce.js';
+
+export async function apiFetch(path, options = {}) {
+  const useNonce = localStorage.getItem('hostInWp') === 'true';
+  const baseUrl = localStorage.getItem('wpEndpoint') || '';
+  const url = path.startsWith('http') ? path : baseUrl.replace(/\/$/, '') + path;
+  options.headers = options.headers || {};
+  if (useNonce) {
+    const nonce = await getNonce();
+    if (!nonce) {
+      console.error('Failed to retrieve WP nonce for auth');
+      throw new Error('Authentication failed (no nonce)');
+    }
+    options.headers['X-WP-Nonce'] = nonce;
+    options.credentials = 'include';
+  } else {
+    const token = localStorage.getItem('jwtToken');
+    if (token) {
+      options.headers['Authorization'] = 'Bearer ' + token;
+    }
+  }
+  const response = await fetch(url, options);
+  return response;
+}
+
+window.apiFetch = apiFetch;

--- a/BlazorWP/wwwroot/js/tinyMceConfig.js
+++ b/BlazorWP/wwwroot/js/tinyMceConfig.js
@@ -123,12 +123,10 @@ window.myTinyMceConfig = {
         alert('No media source selected');
         return { items: [], totalPages: page };
       }
-      const token = localStorage.getItem('jwtToken');
-      const url = source.replace(/\/?$/, '') + `/wp-json/wp/v2/media?per_page=100&page=${page}`;
+      const apiPath = `/wp-json/wp/v2/media?per_page=100&page=${page}`;
+      const url = source.replace(/\/?$/, '') + apiPath;
       try {
-        const res = await fetch(url, {
-          headers: token ? { 'Authorization': 'Bearer ' + token } : {}
-        });
+        const res = await apiFetch(url, { method: 'GET' });
         if (!res.ok) {
           alert('Failed to load media: ' + res.status);
           return { items: [], totalPages: page };


### PR DESCRIPTION
## Summary
- add reusable `apiFetch` utility to attach X-WP-Nonce or JWT headers automatically
- load the new helper in `index.html` and expose it globally
- refactor TinyMCE media loader to use `apiFetch` for authenticated WordPress requests

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689458d6a74083229dbfbda78c4ceca2