### PR TITLE
Centralize WordPress access handling with gate and initializer

### DIFF
--- a/BlazorWP/App.razor
+++ b/BlazorWP/App.razor
@@ -1,4 +1,6 @@
-﻿<Router AppAssembly="@typeof(App).Assembly">
+@inject IAccessInitializer AccessInit
+
+<Router AppAssembly="@typeof(App).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
         <FocusOnNavigate RouteData="@routeData" Selector="h1" />
@@ -11,3 +13,12 @@
     </NotFound>
 </Router>
 <AntContainer />
+
+@code {
+    protected override async Task OnAfterRenderAsync(bool firstRender) {
+        if (firstRender) {
+            Console.WriteLine("App: initializing access");
+            await AccessInit.InitializeOnceAsync();
+        }
+    }
+}

--- a/BlazorWP/Data/AccessContracts.cs
+++ b/BlazorWP/Data/AccessContracts.cs
@@ -1,0 +1,37 @@
+namespace BlazorWP;
+
+public enum AccessMode { Nonce, Jwt }
+
+public interface IAccessModeService {
+    AccessMode Mode { get; }
+    event Action<AccessMode> Changed;
+    void Set(AccessMode mode);
+}
+
+public interface IEndpointState {
+    Uri? BaseAddress { get; }
+    event Action Changed;
+    void Set(string rootUrl);
+}
+
+public interface IAccessGate { Task WaitAsync(); void Pause(); void Open(); }
+
+public interface INonceService {
+    Task<string> GetAsync(CancellationToken ct = default);
+    Task RefreshAsync(CancellationToken ct = default);
+    Task TryWarmAsync(CancellationToken ct = default);
+    Task ClearAsync(CancellationToken ct = default);
+}
+
+public interface IJwtService {
+    Task<string?> GetAsync(CancellationToken ct = default);
+    Task RefreshAsync(CancellationToken ct = default);
+    Task TryWarmAsync(CancellationToken ct = default);
+    Task ClearAsync(CancellationToken ct = default);
+}
+
+public interface IAccessInitializer { Task InitializeOnceAsync(CancellationToken ct = default); }
+
+public interface IAccessSwitcher {
+    Task SwitchToAsync(AccessMode mode, string? newRootUrl = null, CancellationToken ct = default);
+}

--- a/BlazorWP/Data/AccessGate.cs
+++ b/BlazorWP/Data/AccessGate.cs
@@ -1,0 +1,14 @@
+namespace BlazorWP;
+
+public sealed class AccessGate : IAccessGate {
+    private volatile TaskCompletionSource _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public Task WaitAsync() => _tcs.Task;
+    public void Pause() {
+        Console.WriteLine("AccessGate: paused");
+        _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+    public void Open() {
+        Console.WriteLine("AccessGate: opened");
+        _tcs.TrySetResult();
+    }
+}

--- a/BlazorWP/Data/AccessInitializer.cs
+++ b/BlazorWP/Data/AccessInitializer.cs
@@ -1,0 +1,46 @@
+namespace BlazorWP;
+
+public sealed class AccessInitializer : IAccessInitializer
+{
+    private readonly IEndpointState _endpoint;
+    private readonly IAccessGate _gate;
+    private readonly IAccessModeService _mode;
+    private readonly INonceService _nonce;
+    private readonly IJwtService _jwt;
+    private readonly LocalStorageJsInterop _storage;
+    private readonly NavigationManager _nav;
+    private int _started;
+
+    public AccessInitializer(IEndpointState ep, IAccessGate gate, IAccessModeService mode, INonceService nonce, IJwtService jwt, LocalStorageJsInterop storage, NavigationManager nav)
+    {
+        _endpoint = ep; _gate = gate; _mode = mode; _nonce = nonce; _jwt = jwt; _storage = storage; _nav = nav;
+    }
+
+    public async Task InitializeOnceAsync(CancellationToken ct = default)
+    {
+        if (Interlocked.Exchange(ref _started, 1) == 1) return;
+
+        Console.WriteLine("AccessInitializer: starting");
+        _gate.Pause();
+
+        var root = await LoadEndpointFromStorageOrConfigAsync(ct);
+        _endpoint.Set(root);
+
+        if (_mode.Mode == AccessMode.Nonce) await _nonce.TryWarmAsync(ct);
+        else await _jwt.TryWarmAsync(ct);
+
+        _gate.Open();
+        Console.WriteLine("AccessInitializer: completed");
+    }
+
+    private async Task<string> LoadEndpointFromStorageOrConfigAsync(CancellationToken ct)
+    {
+        var root = await _storage.GetItemAsync("wpEndpoint");
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            root = _nav.BaseUri;
+        }
+        Console.WriteLine($"AccessInitializer: loaded root {root}");
+        return root;
+    }
+}

--- a/BlazorWP/Data/AccessModeService.cs
+++ b/BlazorWP/Data/AccessModeService.cs
@@ -1,0 +1,12 @@
+namespace BlazorWP;
+
+public sealed class AccessModeService : IAccessModeService {
+    public AccessMode Mode { get; private set; } = AccessMode.Nonce;
+    public event Action<AccessMode>? Changed;
+    public void Set(AccessMode mode) {
+        if (Mode == mode) return;
+        Mode = mode;
+        Console.WriteLine($"AccessModeService: mode changed to {mode}");
+        Changed?.Invoke(mode);
+    }
+}

--- a/BlazorWP/Data/AccessSwitcher.cs
+++ b/BlazorWP/Data/AccessSwitcher.cs
@@ -1,0 +1,35 @@
+namespace BlazorWP;
+
+public sealed class AccessSwitcher : IAccessSwitcher
+{
+    private readonly IAccessGate _gate;
+    private readonly IAccessModeService _mode;
+    private readonly IEndpointState _endpoint;
+    private readonly INonceService _nonce;
+    private readonly IJwtService _jwt;
+
+    public AccessSwitcher(IAccessGate gate, IAccessModeService mode, IEndpointState ep, INonceService nonce, IJwtService jwt)
+    {
+        _gate = gate; _mode = mode; _endpoint = ep; _nonce = nonce; _jwt = jwt;
+    }
+
+    public async Task SwitchToAsync(AccessMode target, string? newRootUrl = null, CancellationToken ct = default)
+    {
+        if (_mode.Mode == target && newRootUrl is null) return;
+
+        Console.WriteLine($"AccessSwitcher: switching to {target}");
+        _gate.Pause();
+
+        if (newRootUrl is not null) _endpoint.Set(newRootUrl);
+
+        if (target == AccessMode.Nonce) await _jwt.ClearAsync(ct);
+        else await _nonce.ClearAsync(ct);
+
+        _mode.Set(target);
+
+        if (target == AccessMode.Nonce) await _nonce.TryWarmAsync(ct);
+        else await _jwt.TryWarmAsync(ct);
+
+        _gate.Open();
+    }
+}

--- a/BlazorWP/Data/EndpointState.cs
+++ b/BlazorWP/Data/EndpointState.cs
@@ -1,0 +1,11 @@
+namespace BlazorWP;
+
+public sealed class EndpointState : IEndpointState {
+    public Uri? BaseAddress { get; private set; }
+    public event Action? Changed;
+    public void Set(string root) {
+        BaseAddress = new Uri(root.TrimEnd('/') + "/wp-json/");
+        Console.WriteLine($"EndpointState: base address set to {BaseAddress}");
+        Changed?.Invoke();
+    }
+}

--- a/BlazorWP/Data/NonceService.cs
+++ b/BlazorWP/Data/NonceService.cs
@@ -1,0 +1,29 @@
+namespace BlazorWP;
+
+public sealed class NonceService : INonceService {
+    private readonly WpNonceJsInterop _nonceJs;
+    private string? _nonce;
+    public NonceService(WpNonceJsInterop nonceJs) {
+        _nonceJs = nonceJs;
+    }
+    public async Task<string> GetAsync(CancellationToken ct = default) {
+        if (string.IsNullOrEmpty(_nonce)) {
+            _nonce = await _nonceJs.GetNonceAsync();
+            Console.WriteLine($"NonceService: loaded {_nonce}");
+        }
+        return _nonce ?? string.Empty;
+    }
+    public async Task RefreshAsync(CancellationToken ct = default) {
+        Console.WriteLine("NonceService: refresh");
+        _nonce = await _nonceJs.GetNonceAsync();
+    }
+    public async Task TryWarmAsync(CancellationToken ct = default) {
+        Console.WriteLine("NonceService: warm");
+        _nonce = await _nonceJs.GetNonceAsync();
+    }
+    public Task ClearAsync(CancellationToken ct = default) {
+        Console.WriteLine("NonceService: clear");
+        _nonce = null;
+        return Task.CompletedTask;
+    }
+}

--- a/BlazorWP/Pages/ApprovedEmailDemo.razor
+++ b/BlazorWP/Pages/ApprovedEmailDemo.razor
@@ -1,9 +1,7 @@
-@page "/approved-email-demo"
-@using WordPressPCL
 @using System.Net.Http.Json
 @using System.Text.Json
-@inject LocalStorageJsInterop StorageJs
-@inject AuthMessageHandler AuthHandler
+@inject HttpClient Http
+@inject IEndpointState Endpoint
 
 <PageTitle>Approved Email Demo</PageTitle>
 
@@ -57,30 +55,27 @@ else
 
 @code {
     private WordPressClient? client;
-    private HttpClient? httpClient;
     private List<string>? emails;
     private string newEmail = string.Empty;
     private string? status;
 
+    protected override void OnInitialized()
+    {
+        Endpoint.Changed += () => Http.BaseAddress = Endpoint.BaseAddress;
+        Http.BaseAddress = Endpoint.BaseAddress;
+        client = new WordPressClient(Http);
+    }
+
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
-        {
-            return;
-        }
-        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };
-        client = new WordPressClient(httpClient);
         await LoadEmailsAsync();
     }
 
     private async Task LoadEmailsAsync()
     {
-        if (httpClient == null) return;
         try
         {
-            var list = await httpClient.GetFromJsonAsync<List<string>>("approved-email-list/v1/approved-emails");
+            var list = await Http.GetFromJsonAsync<List<string>>("approved-email-list/v1/approved-emails");
             emails = list ?? new();
         }
         catch (Exception ex)
@@ -93,11 +88,11 @@ else
 
     private async Task AddEmailAsync()
     {
-        if (httpClient == null || string.IsNullOrWhiteSpace(newEmail)) return;
+        if (string.IsNullOrWhiteSpace(newEmail)) return;
         status = null;
         try
         {
-            var resp = await httpClient.PostAsJsonAsync("approved-email-list/v1/approved-emails", new { email = newEmail });
+            var resp = await Http.PostAsJsonAsync("approved-email-list/v1/approved-emails", new { email = newEmail });
             resp.EnsureSuccessStatusCode();
             newEmail = string.Empty;
             await LoadEmailsAsync();
@@ -110,11 +105,10 @@ else
 
     private async Task RemoveEmailAsync(string email)
     {
-        if (httpClient == null) return;
         status = null;
         try
         {
-            var resp = await httpClient.DeleteAsync($"approved-email-list/v1/approved-emails/{Uri.EscapeDataString(email)}");
+            var resp = await Http.DeleteAsync($"approved-email-list/v1/approved-emails/{Uri.EscapeDataString(email)}");
             resp.EnsureSuccessStatusCode();
             await LoadEmailsAsync();
         }

--- a/BlazorWP/Pages/Edit.Lifecycle.cs
+++ b/BlazorWP/Pages/Edit.Lifecycle.cs
@@ -107,21 +107,17 @@ public partial class Edit
         }
     }
 
-    private async Task SetupWordPressClientAsync()
+    private Task SetupWordPressClientAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
+        if (Http.BaseAddress == null)
         {
             client = null;
             baseUrl = null;
-            //Console.WriteLine("[SetupWordPressClientAsync] no endpoint configured");
-            return;
+            return Task.CompletedTask;
         }
 
-        baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        //Console.WriteLine($"[SetupWordPressClientAsync] baseUrl={baseUrl}");
-        var handler = AuthHandler;
-        var httpClient = new HttpClient(handler) { BaseAddress = new Uri(baseUrl) };
-        client = new WordPressClient(httpClient);
+        baseUrl = Http.BaseAddress.ToString();
+        client = new WordPressClient(Http);
+        return Task.CompletedTask;
     }
 }

--- a/BlazorWP/Pages/Edit.razor
+++ b/BlazorWP/Pages/Edit.razor
@@ -7,7 +7,7 @@
 @inject IJSRuntime JS
 @inject JwtService JwtService
 @inject LocalStorageJsInterop StorageJs
-@inject AuthMessageHandler AuthHandler
+@inject IEndpointState Endpoint
 @implements IAsyncDisposable
 
 <PageTitle>Edit</PageTitle>

--- a/BlazorWP/Pages/Edit.razor.cs
+++ b/BlazorWP/Pages/Edit.razor.cs
@@ -10,6 +10,12 @@ namespace BlazorWP.Pages;
 
 public partial class Edit : IAsyncDisposable
 {
+    protected override void OnInitialized()
+    {
+        Endpoint.Changed += () => Http.BaseAddress = Endpoint.BaseAddress;
+        Http.BaseAddress = Endpoint.BaseAddress;
+    }
+
     private const string DraftsKey = "editorDrafts";
     private const string ShowTrashedKey = "showTrashed";
 

--- a/BlazorWP/Pages/InviteToken.razor
+++ b/BlazorWP/Pages/InviteToken.razor
@@ -1,13 +1,13 @@
 @page "/invite-token"
 @using System.Net.Http.Json
-@inject LocalStorageJsInterop StorageJs
-@inject AuthMessageHandler AuthHandler
+@inject HttpClient Http
+@inject IEndpointState Endpoint
 
 <PageTitle>Invite Token</PageTitle>
 
 <h1>Invite Token</h1>
 
-@if (httpClient == null)
+@if (Http.BaseAddress == null)
 {
     <p>Please verify a WordPress endpoint on the <NavLink href="/">Home</NavLink> page first.</p>
 }
@@ -29,42 +29,29 @@ else
 }
 
 @code {
-    private HttpClient? httpClient;
-    private InviteResponse? response;
     private string? responseJson;
     private string? error;
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
-        {
-            return;
-        }
-        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };
+        Endpoint.Changed += () => Http.BaseAddress = Endpoint.BaseAddress;
+        Http.BaseAddress = Endpoint.BaseAddress;
     }
 
     private async Task GenerateTokenAsync()
     {
-        if (httpClient == null) return;
-        response = null;
-        error = null;
         responseJson = null;
+        error = null;
         try
         {
-            using var resp = await httpClient.PostAsync("invite/v1/token", null);
+            using var resp = await Http.PostAsync("invite/v1/token", null);
             var json = await resp.Content.ReadAsStringAsync();
             if (resp.IsSuccessStatusCode)
             {
-// no re-serialization, just indent in place
-responseJson = JsonDocument
+                responseJson = JsonDocument
   .Parse(json)
   .RootElement
   .GetRawText();
-
-
-
             }
             else
             {
@@ -75,12 +62,5 @@ responseJson = JsonDocument
         {
             error = ex.Message;
         }
-    }
-
-    private class InviteResponse
-    {
-        public string? token { get; set; }
-        public int expiresIn { get; set; }
-        public string? issuedAt { get; set; }
     }
 }

--- a/BlazorWP/Pages/PclDemo.razor
+++ b/BlazorWP/Pages/PclDemo.razor
@@ -1,8 +1,9 @@
 @page "/pcl-demo"
 @using WordPressPCL
-@inject LocalStorageJsInterop StorageJs
 @inject IJSRuntime JS
-@inject JwtService JwtService
+@inject IJwtService JwtService
+@inject HttpClient Http
+@inject IEndpointState Endpoint
 
 <PageTitle>PCL Demo</PageTitle>
 
@@ -43,26 +44,14 @@ else
 
 @code {
     private WordPressClient? client;
-    private string? baseUrl;
     private List<ApiEndpoint> endpoints = new();
     private string? jwtToken;
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
-        {
-            return;
-        }
-
-        baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        client = new WordPressClient(baseUrl);
-        jwtToken = await JwtService.GetCurrentJwtAsync();
-        if (!string.IsNullOrEmpty(jwtToken))
-        {
-            client.Auth.SetJWToken(jwtToken);
-        }
-
+        Endpoint.Changed += () => Http.BaseAddress = Endpoint.BaseAddress;
+        Http.BaseAddress = Endpoint.BaseAddress;
+        client = new WordPressClient(Http);
         endpoints = new()
         {
             new ApiEndpoint("Posts", "wp/v2/posts", async c => await c.Posts.GetAllAsync()),
@@ -75,7 +64,6 @@ else
             new ApiEndpoint("Taxonomies", "wp/v2/taxonomies", async c => await c.Taxonomies.GetAllAsync()),
             new ApiEndpoint("Post Types", "wp/v2/types", async c => await c.PostTypes.GetAllAsync()),
             new ApiEndpoint("Post Statuses", "wp/v2/statuses", async c => await c.PostStatuses.GetAllAsync()),
-            // new ApiEndpoint("Settings", "wp/v2/settings", async c => await c.Settings.GetAsync()),
             new ApiEndpoint("Plugins", "wp/v2/plugins", async c => await c.Plugins.GetAllAsync()),
             new ApiEndpoint("Themes", "wp/v2/themes", async c => await c.Themes.GetAllAsync())
         };
@@ -86,12 +74,6 @@ else
         if (client == null)
         {
             return;
-        }
-
-        jwtToken = await JwtService.GetCurrentJwtAsync();
-        if (!string.IsNullOrEmpty(jwtToken))
-        {
-            client.Auth.SetJWToken(jwtToken);
         }
 
         try
@@ -108,18 +90,14 @@ else
 
     private async Task CopyCurl(ApiEndpoint ep)
     {
-        if (baseUrl == null)
-        {
-            return;
-        }
-
-        jwtToken = await JwtService.GetCurrentJwtAsync();
+        jwtToken = await JwtService.GetAsync();
         var command = GetCurlCommand(ep);
         await JS.InvokeVoidAsync("navigator.clipboard.writeText", command);
     }
 
     private string GetCurlCommand(ApiEndpoint ep)
     {
+        var baseUrl = Http.BaseAddress?.ToString();
         if (baseUrl == null)
         {
             return string.Empty;

--- a/BlazorWP/Pages/UploadPdf.razor
+++ b/BlazorWP/Pages/UploadPdf.razor
@@ -6,9 +6,9 @@
 @using System.Text.Json
 @using System.IO
 @using System.Net.Http
-@inject LocalStorageJsInterop StorageJs
 @inject UploadPdfJsInterop PdfJs
-@inject AuthMessageHandler AuthHandler
+@inject HttpClient Http
+@inject IEndpointState Endpoint
 
 <PageTitle>Upload PDF</PageTitle>
 
@@ -79,7 +79,6 @@ else
 
 @code {
     private WordPressClient? client;
-    private HttpClient? httpClient;
     private IBrowserFile? _file;
     private string? status;
     private int uploadProgress;
@@ -91,6 +90,13 @@ else
     private Dictionary<string, string>? sizePreviews;
 
     private record WpSize(string Name, int Width, int Height, string CropMode, string Notes);
+
+    protected override void OnInitialized()
+    {
+        Endpoint.Changed += () => Http.BaseAddress = Endpoint.BaseAddress;
+        Http.BaseAddress = Endpoint.BaseAddress;
+        client = new WordPressClient(Http);
+    }
 
     private void CalculateWpSizes()
     {
@@ -117,15 +123,6 @@ else
             new("large", ScaledWidth(1024), ScaledHeight(1024), "soft (max)", "Max width 1024"),
             new("full", w, h, "n/a", "Full first page")
         };
-    }
-
-    protected override async Task OnInitializedAsync()
-    {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint)) return;
-        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };
-        client = new WordPressClient(httpClient);
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -175,7 +172,7 @@ else
         status = null; uploadProgress = 0; isUploading = true;
         try
         {
-            var endpoint = new Uri(httpClient!.BaseAddress!, "myplugin/v1/media/bundle");
+            var endpoint = new Uri(Http.BaseAddress!, "myplugin/v1/media/bundle");
             using var form = new MultipartFormDataContent();
 
             using var pdfStream = _file.OpenReadStream(long.MaxValue);
@@ -204,7 +201,7 @@ else
 
             form.Add(new StringContent(JsonSerializer.Serialize(dimensions)), "dimensions");
 
-            var resp = await httpClient!.PostAsync(endpoint, form);
+            var resp = await Http.PostAsync(endpoint, form);
             resp.EnsureSuccessStatusCode();
             status = "Upload complete";
             uploadProgress = 100;

--- a/BlazorWP/Pages/WpUsers.razor
+++ b/BlazorWP/Pages/WpUsers.razor
@@ -1,8 +1,8 @@
 @page "/wp-users"
 @using WordPressPCL
 @using WordPressPCL.Models
-@inject LocalStorageJsInterop StorageJs
-@inject JwtService JwtService
+@inject HttpClient Http
+@inject IEndpointState Endpoint
 
 <PageTitle>WordPress Users</PageTitle>
 
@@ -54,26 +54,18 @@ else
     private User? selectedUser;
     private string? error;
 
+    protected override void OnInitialized()
+    {
+        Endpoint.Changed += () => Http.BaseAddress = Endpoint.BaseAddress;
+        Http.BaseAddress = Endpoint.BaseAddress;
+        client = new WordPressClient(Http);
+    }
+
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
-        {
-            return;
-        }
-
-        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        client = new WordPressClient(baseUrl);
-
-        var token = await JwtService.GetCurrentJwtAsync();
-        if (!string.IsNullOrEmpty(token))
-        {
-            client.Auth.SetJWToken(token);
-        }
-
         try
         {
-            users = await client.Users.GetAllAsync();
+            users = await client!.Users.GetAllAsync();
         }
         catch (Exception ex)
         {
@@ -88,4 +80,3 @@ else
 
     private string GetActiveClass(User user) => selectedUser?.Id == user.Id ? "active" : string.Empty;
 }
-

--- a/BlazorWP/Program.cs
+++ b/BlazorWP/Program.cs
@@ -9,38 +9,50 @@ namespace BlazorWP
     {
         public static async Task Main(string[] args)
         {
-            // 1) This pulls in wwwroot/appsettings.json (+ env overrides)
             var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
-            // 2) Register your root components
             builder.RootComponents.Add<App>("#app");
             builder.RootComponents.Add<HeadOutlet>("head::after");
 
-            // 3) Your services
+            // state + coordination
+            builder.Services.AddScoped<IEndpointState, EndpointState>();
+            builder.Services.AddScoped<IAccessModeService, AccessModeService>();
+            builder.Services.AddScoped<IAccessGate, AccessGate>();
+
+            // auth primitives
+            builder.Services.AddScoped<WpNonceJsInterop>();
+            builder.Services.AddScoped<NonceService>();
+            builder.Services.AddScoped<INonceService>(sp => sp.GetRequiredService<NonceService>());
+            builder.Services.AddScoped<JwtService>();
+            builder.Services.AddScoped<IJwtService>(sp => sp.GetRequiredService<JwtService>());
+
+            // initializer + switcher
+            builder.Services.AddScoped<IAccessInitializer, AccessInitializer>();
+            builder.Services.AddScoped<IAccessSwitcher, AccessSwitcher>();
+
+            // HTTP
             builder.Services.AddScoped<AuthMessageHandler>();
-            builder.Services.AddScoped(sp =>
-            {
-                var handler = sp.GetRequiredService<AuthMessageHandler>();
-                return new HttpClient(handler) { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) };
+            builder.Services.AddHttpClient("WpApi")
+                .AddHttpMessageHandler<AuthMessageHandler>();
+            builder.Services.AddScoped(sp => {
+                var factory = sp.GetRequiredService<IHttpClientFactory>();
+                var ep = sp.GetRequiredService<IEndpointState>();
+                var http = factory.CreateClient("WpApi");
+                http.BaseAddress = ep.BaseAddress;
+                return http;
             });
+
             builder.Services.AddMudServices();
             builder.Services.AddPanoramicDataBlazor();
             builder.Services.AddAntDesign();
-            builder.Services.AddScoped<JwtService>();
             builder.Services.AddScoped<UploadPdfJsInterop>();
-            builder.Services.AddScoped<WpNonceJsInterop>();
             builder.Services.AddScoped<WpEndpointSyncJsInterop>();
             builder.Services.AddScoped<LocalStorageJsInterop>();
             builder.Services.AddScoped<SessionStorageJsInterop>();
             builder.Services.AddScoped<WpMediaJsInterop>();
 
-            // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();
-
-            // 6) Now that the JSON has been loaded, enumerate via ILogger
             var config = host.Services.GetRequiredService<IConfiguration>();
-
-            // 7) And finally run
             await host.RunAsync();
         }
     }


### PR DESCRIPTION
## Summary
- Add scoped access services (gate, mode, endpoint) with initializer and switcher
- Replace ad-hoc header injection with console-logged AuthMessageHandler and HttpClient factory
- Refactor pages to use scoped HttpClient with runtime endpoint updates

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeda6f261c8322b6869b17764508ca