### PR TITLE
Fix missing imports for NavigationManager and WordPressClient

### DIFF
--- a/BlazorWP/Data/AccessInitializer.cs
+++ b/BlazorWP/Data/AccessInitializer.cs
@@ -1,3 +1,5 @@
+using Microsoft.AspNetCore.Components;
+
 namespace BlazorWP;
 
 public sealed class AccessInitializer : IAccessInitializer

--- a/BlazorWP/Pages/ApprovedEmailDemo.razor
+++ b/BlazorWP/Pages/ApprovedEmailDemo.razor
@@ -1,5 +1,6 @@
 @using System.Net.Http.Json
 @using System.Text.Json
+@using WordPressPCL
 @inject HttpClient Http
 @inject IEndpointState Endpoint
 


### PR DESCRIPTION
## Summary
- bring in NavigationManager dependency for AccessInitializer
- add WordPressPCL using directive for ApprovedEmailDemo

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aeddbdadc08322b3c3d98066341d01