### PR TITLE
feat: centralize WordPress client setup

### DIFF
--- a/BlazorWP/Data/WordPressApiService.cs
+++ b/BlazorWP/Data/WordPressApiService.cs
@@ -1,0 +1,55 @@
+using WordPressPCL;
+
+namespace BlazorWP;
+
+public sealed class WordPressApiService
+{
+    private readonly AuthMessageHandler _auth;
+    private readonly LocalStorageJsInterop _storage;
+    private WordPressClient? _client;
+    private HttpClient? _httpClient;
+    private string? _endpoint;
+    private string? _baseUrl;
+
+    public WordPressApiService(AuthMessageHandler auth, LocalStorageJsInterop storage)
+    {
+        _auth = auth;
+        _storage = storage;
+    }
+
+    public async Task<WordPressClient?> GetClientAsync()
+    {
+        var endpoint = await _storage.GetItemAsync("wpEndpoint");
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            _client = null;
+            _httpClient = null;
+            _baseUrl = null;
+            _endpoint = null;
+            return null;
+        }
+
+        if (_client == null || !string.Equals(endpoint, _endpoint, StringComparison.OrdinalIgnoreCase))
+        {
+            SetEndpoint(endpoint);
+        }
+
+        return _client;
+    }
+
+    public async Task<HttpClient?> GetHttpClientAsync()
+    {
+        await GetClientAsync();
+        return _httpClient;
+    }
+
+    public void SetEndpoint(string endpoint)
+    {
+        _endpoint = endpoint;
+        _baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
+        _httpClient = new HttpClient(_auth) { BaseAddress = new Uri(_baseUrl) };
+        _client = new WordPressClient(_httpClient);
+    }
+
+    public string? BaseUrl => _baseUrl;
+}

--- a/BlazorWP/Pages/ApprovedEmailDemo.razor
+++ b/BlazorWP/Pages/ApprovedEmailDemo.razor
@@ -2,8 +2,7 @@
 @using WordPressPCL
 @using System.Net.Http.Json
 @using System.Text.Json
-@inject LocalStorageJsInterop StorageJs
-@inject AuthMessageHandler AuthHandler
+@inject WordPressApiService Api
 
 <PageTitle>Approved Email Demo</PageTitle>
 
@@ -64,14 +63,12 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
+        client = await Api.GetClientAsync();
+        httpClient = await Api.GetHttpClientAsync();
+        if (client == null || httpClient == null)
         {
             return;
         }
-        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };
-        client = new WordPressClient(httpClient);
         await LoadEmailsAsync();
     }
 

--- a/BlazorWP/Pages/Edit.Lifecycle.cs
+++ b/BlazorWP/Pages/Edit.Lifecycle.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using System.Linq;
 using System.Collections.Generic;
-using System.Net.Http;
 using Microsoft.JSInterop;
 using WordPressPCL;
 using WordPressPCL.Models;
@@ -109,19 +108,14 @@ public partial class Edit
 
     private async Task SetupWordPressClientAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
+        client = await Api.GetClientAsync();
+        baseUrl = Api.BaseUrl;
+        if (client == null || baseUrl == null)
         {
             client = null;
             baseUrl = null;
             //Console.WriteLine("[SetupWordPressClientAsync] no endpoint configured");
             return;
         }
-
-        baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        //Console.WriteLine($"[SetupWordPressClientAsync] baseUrl={baseUrl}");
-        var handler = AuthHandler;
-        var httpClient = new HttpClient(handler) { BaseAddress = new Uri(baseUrl) };
-        client = new WordPressClient(httpClient);
     }
 }

--- a/BlazorWP/Pages/Edit.razor
+++ b/BlazorWP/Pages/Edit.razor
@@ -7,7 +7,7 @@
 @inject IJSRuntime JS
 @inject JwtService JwtService
 @inject LocalStorageJsInterop StorageJs
-@inject AuthMessageHandler AuthHandler
+@inject WordPressApiService Api
 @implements IAsyncDisposable
 
 <PageTitle>Edit</PageTitle>

--- a/BlazorWP/Pages/InviteToken.razor
+++ b/BlazorWP/Pages/InviteToken.razor
@@ -1,7 +1,6 @@
 @page "/invite-token"
 @using System.Net.Http.Json
-@inject LocalStorageJsInterop StorageJs
-@inject AuthMessageHandler AuthHandler
+@inject WordPressApiService Api
 
 <PageTitle>Invite Token</PageTitle>
 
@@ -36,13 +35,11 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
+        httpClient = await Api.GetHttpClientAsync();
+        if (httpClient == null)
         {
             return;
         }
-        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };
     }
 
     private async Task GenerateTokenAsync()

--- a/BlazorWP/Pages/PclDemo.razor
+++ b/BlazorWP/Pages/PclDemo.razor
@@ -1,8 +1,8 @@
 @page "/pcl-demo"
 @using WordPressPCL
-@inject LocalStorageJsInterop StorageJs
 @inject IJSRuntime JS
 @inject JwtService JwtService
+@inject WordPressApiService Api
 
 <PageTitle>PCL Demo</PageTitle>
 
@@ -49,18 +49,12 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
+        client = await Api.GetClientAsync();
+        baseUrl = Api.BaseUrl;
+        jwtToken = await JwtService.GetCurrentJwtAsync();
+        if (client == null || baseUrl == null)
         {
             return;
-        }
-
-        baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        client = new WordPressClient(baseUrl);
-        jwtToken = await JwtService.GetCurrentJwtAsync();
-        if (!string.IsNullOrEmpty(jwtToken))
-        {
-            client.Auth.SetJWToken(jwtToken);
         }
 
         endpoints = new()
@@ -89,10 +83,6 @@ else
         }
 
         jwtToken = await JwtService.GetCurrentJwtAsync();
-        if (!string.IsNullOrEmpty(jwtToken))
-        {
-            client.Auth.SetJWToken(jwtToken);
-        }
 
         try
         {

--- a/BlazorWP/Pages/UploadPdf.razor
+++ b/BlazorWP/Pages/UploadPdf.razor
@@ -6,9 +6,8 @@
 @using System.Text.Json
 @using System.IO
 @using System.Net.Http
-@inject LocalStorageJsInterop StorageJs
 @inject UploadPdfJsInterop PdfJs
-@inject AuthMessageHandler AuthHandler
+@inject WordPressApiService Api
 
 <PageTitle>Upload PDF</PageTitle>
 
@@ -121,11 +120,9 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint)) return;
-        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };
-        client = new WordPressClient(httpClient);
+        httpClient = await Api.GetHttpClientAsync();
+        client = await Api.GetClientAsync();
+        if (httpClient == null || client == null) return;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/BlazorWP/Pages/WpUsers.razor
+++ b/BlazorWP/Pages/WpUsers.razor
@@ -1,8 +1,7 @@
 @page "/wp-users"
 @using WordPressPCL
 @using WordPressPCL.Models
-@inject LocalStorageJsInterop StorageJs
-@inject JwtService JwtService
+@inject WordPressApiService Api
 
 <PageTitle>WordPress Users</PageTitle>
 
@@ -56,19 +55,10 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
+        client = await Api.GetClientAsync();
+        if (client == null)
         {
             return;
-        }
-
-        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        client = new WordPressClient(baseUrl);
-
-        var token = await JwtService.GetCurrentJwtAsync();
-        if (!string.IsNullOrEmpty(token))
-        {
-            client.Auth.SetJWToken(token);
         }
 
         try

--- a/BlazorWP/Program.cs
+++ b/BlazorWP/Program.cs
@@ -33,6 +33,7 @@ namespace BlazorWP
             builder.Services.AddScoped<LocalStorageJsInterop>();
             builder.Services.AddScoped<SessionStorageJsInterop>();
             builder.Services.AddScoped<WpMediaJsInterop>();
+            builder.Services.AddScoped<WordPressApiService>();
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();


### PR DESCRIPTION
## Summary
- add `WordPressApiService` to manage endpoint-based WordPressClient and HttpClient instances
- register the service in dependency injection
- refactor pages to use the centralized API service instead of building clients per component

## Testing
- `dotnet build` *(fails: command not found and unable to install dotnet due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68af91d4b93483228407092edff98843