### PR TITLE
feat: centralize WordPress client setup

### DIFF
--- a/BlazorWP/Data/WordPressApiService.cs
+++ b/BlazorWP/Data/WordPressApiService.cs
@@ -1,0 +1,42 @@
+using WordPressPCL;
+using System.Net.Http;
+using System;
+using System.Threading.Tasks;
+
+namespace BlazorWP;
+
+public sealed class WordPressApiService
+{
+    private readonly AuthMessageHandler _auth;
+    private readonly LocalStorageJsInterop _storage;
+    private WordPressClient? _client;
+
+    public WordPressApiService(AuthMessageHandler auth, LocalStorageJsInterop storage)
+    {
+        _auth = auth;
+        _storage = storage;
+    }
+
+    public void SetEndpoint(string endpoint)
+    {
+        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
+        _client = new WordPressClient(new HttpClient(_auth) { BaseAddress = new Uri(baseUrl) });
+    }
+
+    public async Task<WordPressClient?> GetClientAsync()
+    {
+        if (_client != null)
+        {
+            return _client;
+        }
+        var endpoint = await _storage.GetItemAsync("wpEndpoint");
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            return null;
+        }
+        SetEndpoint(endpoint);
+        return _client;
+    }
+
+    public WordPressClient? Client => _client;
+}

--- a/BlazorWP/Pages/ApprovedEmailDemo.razor
+++ b/BlazorWP/Pages/ApprovedEmailDemo.razor
@@ -2,8 +2,7 @@
 @using WordPressPCL
 @using System.Net.Http.Json
 @using System.Text.Json
-@inject LocalStorageJsInterop StorageJs
-@inject AuthMessageHandler AuthHandler
+@inject WordPressApiService Api
 
 <PageTitle>Approved Email Demo</PageTitle>
 
@@ -64,14 +63,13 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
+        var wp = await Api.GetClientAsync();
+        if (wp == null)
         {
             return;
         }
-        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };
-        client = new WordPressClient(httpClient);
+        client = wp;
+        httpClient = wp.HttpClient;
         await LoadEmailsAsync();
     }
 

--- a/BlazorWP/Pages/Edit.Lifecycle.cs
+++ b/BlazorWP/Pages/Edit.Lifecycle.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using System.Linq;
 using System.Collections.Generic;
-using System.Net.Http;
 using Microsoft.JSInterop;
 using WordPressPCL;
 using WordPressPCL.Models;
@@ -109,19 +108,6 @@ public partial class Edit
 
     private async Task SetupWordPressClientAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
-        {
-            client = null;
-            baseUrl = null;
-            //Console.WriteLine("[SetupWordPressClientAsync] no endpoint configured");
-            return;
-        }
-
-        baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        //Console.WriteLine($"[SetupWordPressClientAsync] baseUrl={baseUrl}");
-        var handler = AuthHandler;
-        var httpClient = new HttpClient(handler) { BaseAddress = new Uri(baseUrl) };
-        client = new WordPressClient(httpClient);
+        client = await Api.GetClientAsync();
     }
 }

--- a/BlazorWP/Pages/Edit.razor
+++ b/BlazorWP/Pages/Edit.razor
@@ -3,11 +3,10 @@
 @using System.Text.Json
 @using System.Threading
 @using Humanizer
-@inject HttpClient Http
 @inject IJSRuntime JS
 @inject JwtService JwtService
 @inject LocalStorageJsInterop StorageJs
-@inject AuthMessageHandler AuthHandler
+@inject WordPressApiService Api
 @implements IDisposable
 @implements IAsyncDisposable
 

--- a/BlazorWP/Pages/Edit.razor.cs
+++ b/BlazorWP/Pages/Edit.razor.cs
@@ -37,7 +37,6 @@ public partial class Edit : IDisposable, IAsyncDisposable
     private readonly string[] refreshOptions = new[] { "10", "25", "50", "100", "all" };
     private readonly string[] availableStatuses = new[] { "draft", "pending", "publish", "private", "trash" };
     private WordPressClient? client;
-    private string? baseUrl;
     private int? postId;
 
     private IEnumerable<PostSummary> DisplayPosts =>

--- a/BlazorWP/Pages/InviteToken.razor
+++ b/BlazorWP/Pages/InviteToken.razor
@@ -1,7 +1,6 @@
 @page "/invite-token"
 @using System.Net.Http.Json
-@inject LocalStorageJsInterop StorageJs
-@inject AuthMessageHandler AuthHandler
+@inject WordPressApiService Api
 
 <PageTitle>Invite Token</PageTitle>
 
@@ -36,13 +35,12 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
+        var wp = await Api.GetClientAsync();
+        if (wp == null)
         {
             return;
         }
-        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };
+        httpClient = wp.HttpClient;
     }
 
     private async Task GenerateTokenAsync()
@@ -57,14 +55,11 @@ else
             var json = await resp.Content.ReadAsStringAsync();
             if (resp.IsSuccessStatusCode)
             {
-// no re-serialization, just indent in place
-responseJson = JsonDocument
-  .Parse(json)
-  .RootElement
-  .GetRawText();
-
-
-
+                // no re-serialization, just indent in place
+                responseJson = JsonDocument
+                    .Parse(json)
+                    .RootElement
+                    .GetRawText();
             }
             else
             {

--- a/BlazorWP/Pages/PclDemo.razor
+++ b/BlazorWP/Pages/PclDemo.razor
@@ -1,8 +1,8 @@
 @page "/pcl-demo"
 @using WordPressPCL
-@inject LocalStorageJsInterop StorageJs
 @inject IJSRuntime JS
 @inject JwtService JwtService
+@inject WordPressApiService Api
 
 <PageTitle>PCL Demo</PageTitle>
 
@@ -49,14 +49,14 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
+        var wp = await Api.GetClientAsync();
+        if (wp == null)
         {
             return;
         }
 
-        baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        client = new WordPressClient(baseUrl);
+        client = wp;
+        baseUrl = wp.HttpClient.BaseAddress?.ToString();
         jwtToken = await JwtService.GetCurrentJwtAsync();
         if (!string.IsNullOrEmpty(jwtToken))
         {

--- a/BlazorWP/Pages/UploadPdf.razor
+++ b/BlazorWP/Pages/UploadPdf.razor
@@ -6,9 +6,8 @@
 @using System.Text.Json
 @using System.IO
 @using System.Net.Http
-@inject LocalStorageJsInterop StorageJs
 @inject UploadPdfJsInterop PdfJs
-@inject AuthMessageHandler AuthHandler
+@inject WordPressApiService Api
 
 <PageTitle>Upload PDF</PageTitle>
 
@@ -121,11 +120,10 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint)) return;
-        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };
-        client = new WordPressClient(httpClient);
+        var wp = await Api.GetClientAsync();
+        if (wp == null) return;
+        client = wp;
+        httpClient = wp.HttpClient;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/BlazorWP/Pages/WpUsers.razor
+++ b/BlazorWP/Pages/WpUsers.razor
@@ -1,8 +1,8 @@
 @page "/wp-users"
 @using WordPressPCL
 @using WordPressPCL.Models
-@inject LocalStorageJsInterop StorageJs
 @inject JwtService JwtService
+@inject WordPressApiService Api
 
 <PageTitle>WordPress Users</PageTitle>
 
@@ -56,14 +56,13 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
+        var wp = await Api.GetClientAsync();
+        if (wp == null)
         {
             return;
         }
 
-        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        client = new WordPressClient(baseUrl);
+        client = wp;
 
         var token = await JwtService.GetCurrentJwtAsync();
         if (!string.IsNullOrEmpty(token))

--- a/BlazorWP/Program.cs
+++ b/BlazorWP/Program.cs
@@ -33,6 +33,7 @@ namespace BlazorWP
             builder.Services.AddScoped<LocalStorageJsInterop>();
             builder.Services.AddScoped<SessionStorageJsInterop>();
             builder.Services.AddScoped<WpMediaJsInterop>();
+            builder.Services.AddScoped<WordPressApiService>();
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();


### PR DESCRIPTION
## Summary
- add WordPressApiService to encapsulate endpoint lookup and WordPress client creation
- register WordPressApiService and migrate pages to use it

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68afaaade28c83228309f813bf306320