### PR TITLE
Expose WordPress HttpClient via service

### DIFF
--- a/BlazorWP/Data/WordPressApiService.cs
+++ b/BlazorWP/Data/WordPressApiService.cs
@@ -10,6 +10,7 @@ public sealed class WordPressApiService
     private readonly AuthMessageHandler _auth;
     private readonly LocalStorageJsInterop _storage;
     private WordPressClient? _client;
+    private HttpClient? _httpClient;
 
     public WordPressApiService(AuthMessageHandler auth, LocalStorageJsInterop storage)
     {
@@ -20,7 +21,8 @@ public sealed class WordPressApiService
     public void SetEndpoint(string endpoint)
     {
         var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        _client = new WordPressClient(new HttpClient(_auth) { BaseAddress = new Uri(baseUrl) });
+        _httpClient = new HttpClient(_auth) { BaseAddress = new Uri(baseUrl) };
+        _client = new WordPressClient(_httpClient);
     }
 
     public async Task<WordPressClient?> GetClientAsync()
@@ -39,4 +41,5 @@ public sealed class WordPressApiService
     }
 
     public WordPressClient? Client => _client;
+    public HttpClient? HttpClient => _httpClient;
 }

--- a/BlazorWP/Pages/ApprovedEmailDemo.razor
+++ b/BlazorWP/Pages/ApprovedEmailDemo.razor
@@ -64,12 +64,12 @@ else
     protected override async Task OnInitializedAsync()
     {
         var wp = await Api.GetClientAsync();
-        if (wp == null)
+        if (wp == null || Api.HttpClient == null)
         {
             return;
         }
         client = wp;
-        httpClient = wp.HttpClient;
+        httpClient = Api.HttpClient;
         await LoadEmailsAsync();
     }
 

--- a/BlazorWP/Pages/InviteToken.razor
+++ b/BlazorWP/Pages/InviteToken.razor
@@ -36,11 +36,11 @@ else
     protected override async Task OnInitializedAsync()
     {
         var wp = await Api.GetClientAsync();
-        if (wp == null)
+        if (wp == null || Api.HttpClient == null)
         {
             return;
         }
-        httpClient = wp.HttpClient;
+        httpClient = Api.HttpClient;
     }
 
     private async Task GenerateTokenAsync()

--- a/BlazorWP/Pages/PclDemo.razor
+++ b/BlazorWP/Pages/PclDemo.razor
@@ -50,13 +50,13 @@ else
     protected override async Task OnInitializedAsync()
     {
         var wp = await Api.GetClientAsync();
-        if (wp == null)
+        if (wp == null || Api.HttpClient == null)
         {
             return;
         }
 
         client = wp;
-        baseUrl = wp.HttpClient.BaseAddress?.ToString();
+        baseUrl = Api.HttpClient.BaseAddress?.ToString();
         jwtToken = await JwtService.GetCurrentJwtAsync();
         if (!string.IsNullOrEmpty(jwtToken))
         {

--- a/BlazorWP/Pages/UploadPdf.razor
+++ b/BlazorWP/Pages/UploadPdf.razor
@@ -121,9 +121,9 @@ else
     protected override async Task OnInitializedAsync()
     {
         var wp = await Api.GetClientAsync();
-        if (wp == null) return;
+        if (wp == null || Api.HttpClient == null) return;
         client = wp;
-        httpClient = wp.HttpClient;
+        httpClient = Api.HttpClient;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)


### PR DESCRIPTION
## Summary
- Expose underlying HttpClient from `WordPressApiService`
- Update pages to consume `Api.HttpClient` instead of non-existent `WordPressClient.HttpClient`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68afadda26c48322947e51054a058759