### PR TITLE
Highlight home menu when dev query absent

### DIFF
--- a/BlazorWP/Layout/NavMenu.razor
+++ b/BlazorWP/Layout/NavMenu.razor
@@ -1,4 +1,7 @@
-﻿<div class="top-row ps-3 navbar navbar-dark">
+@using Microsoft.AspNetCore.WebUtilities
+@inject NavigationManager Navigation
+@implements IDisposable
+<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="">BlazorWP</a>
         <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
@@ -8,7 +11,7 @@
 </div>
 
 <div class="@NavMenuCssClass nav-scrollable" @onclick="ToggleNavMenu">
-    <nav class="nav flex-column">
+    <nav class="nav flex-column @(isDev ? null : "home-highlight")">
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
                 <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> Home
@@ -105,10 +108,36 @@
 @code {
     private bool collapseNavMenu = true;
 
+    private bool isDev;
+
     private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
+
+    protected override void OnInitialized()
+    {
+        UpdateDevFlag();
+        Navigation.LocationChanged += OnLocationChanged;
+    }
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs args)
+    {
+        UpdateDevFlag();
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void UpdateDevFlag()
+    {
+        var uri = Navigation.ToAbsoluteUri(Navigation.Uri);
+        var query = QueryHelpers.ParseQuery(uri.Query);
+        isDev = query.ContainsKey("dev");
+    }
 
     private void ToggleNavMenu()
     {
         collapseNavMenu = !collapseNavMenu;
+    }
+
+    public void Dispose()
+    {
+        Navigation.LocationChanged -= OnLocationChanged;
     }
 }

--- a/BlazorWP/Layout/NavMenu.razor.css
+++ b/BlazorWP/Layout/NavMenu.razor.css
@@ -69,6 +69,11 @@
     color: white;
 }
 
+.home-highlight .nav-item ::deep a.active {
+    background-color: yellow;
+    color: black;
+}
+
 @media (min-width: 641px) {
     .navbar-toggler {
         display: none;


### PR DESCRIPTION
## Summary
- Highlight active Home menu item with yellow background unless `?dev` query present
- Detect `dev` query parameter via NavigationManager and toggle CSS class

## Testing
- `dotnet build BlazorWP.sln` *(failed: command not found)*
- `apt-get update` *(failed: 403 Forbidden from package repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b147b42af48322b18123da04517988