### PR TITLE
Store credentials after JWT login

### DIFF
--- a/BlazorWP/Data/CredentialManagerJsInterop.cs
+++ b/BlazorWP/Data/CredentialManagerJsInterop.cs
@@ -1,0 +1,45 @@
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public class CredentialManagerJsInterop : IDisposable, IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private IJSObjectReference? _module;
+
+    public CredentialManagerJsInterop(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private async ValueTask<IJSObjectReference> GetModuleAsync()
+    {
+        if (_module == null)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/credentialManager.js");
+        }
+        return _module;
+    }
+
+    public async ValueTask StoreAsync(string username, string password)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("storeCredentials", username, password);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module != null)
+        {
+            await _module.DisposeAsync();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_module != null)
+        {
+            _module.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+}

--- a/BlazorWP/Pages/Home.razor
+++ b/BlazorWP/Pages/Home.razor
@@ -188,6 +188,8 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
     private IJSRuntime JS { get; set; } = default!;
     [Inject]
     private IConfiguration Config { get; set; } = default!;
+    [Inject]
+    private CredentialManagerJsInterop CredentialJs { get; set; } = default!;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -539,6 +541,7 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
                                 Token = jwtToken
                             };
                             await SaveJwtInfoAsync(verifiedEndpoint, info);
+                            await CredentialJs.StoreAsync(jwtUsername, jwtPassword);
                         }
                     }
                     else

--- a/BlazorWP/Program.cs
+++ b/BlazorWP/Program.cs
@@ -29,6 +29,7 @@ namespace BlazorWP
             builder.Services.AddScoped<WpEndpointSyncJsInterop>();
             builder.Services.AddScoped<LocalStorageJsInterop>();
             builder.Services.AddScoped<SessionStorageJsInterop>();
+            builder.Services.AddScoped<CredentialManagerJsInterop>();
             builder.Services.AddScoped<WpMediaJsInterop>();
             builder.Services.AddScoped<WordPressApiService>();
 

--- a/BlazorWP/wwwroot/js/credentialManager.js
+++ b/BlazorWP/wwwroot/js/credentialManager.js
@@ -1,0 +1,10 @@
+export async function storeCredentials(username, password) {
+  if ('credentials' in navigator && window.PasswordCredential) {
+    try {
+      const cred = new PasswordCredential({ id: username, password: password });
+      await navigator.credentials.store(cred);
+    } catch {
+      // ignore errors
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add CredentialManagerJsInterop with JS module to save credentials using the Credential Management API
- register interop service and call it after successful JWT login

## Testing
- `dotnet build BlazorWP/BlazorWP.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b29727851083228f1a66b6538df089