### PR TITLE
Wrap JWT login fields in EditForm

### DIFF
--- a/BlazorWP/Pages/Home.razor
+++ b/BlazorWP/Pages/Home.razor
@@ -26,14 +26,25 @@
 @if (showJwtLogin && !string.IsNullOrEmpty(verifiedEndpoint))
 {
     <div class="mt-2">
-        <input class="form-control mb-2" placeholder="Username" @bind="jwtUsername" />
-        <div class="input-group mb-2">
-            <input class="form-control" type="@PasswordInputType" placeholder="Password" @bind="jwtPassword" />
-            <button class="btn btn-outline-secondary" type="button" @onclick="TogglePasswordVisibility">
-                <i class="bi @PasswordToggleIcon" aria-hidden="true"></i>
-            </button>
-        </div>
-        <button class="btn btn-primary" @onclick="JwtLoginAsync">Login</button>
+        <EditForm OnValidSubmit="JwtLoginAsync" FormName="jwtForm">
+            <InputText class="form-control mb-2"
+                       @bind-Value="jwtUsername"
+                       name="username"
+                       autocomplete="username"
+                       placeholder="Username" />
+            <div class="input-group mb-2">
+                <InputText class="form-control"
+                           type="@PasswordInputType"
+                           @bind-Value="jwtPassword"
+                           name="password"
+                           autocomplete="current-password"
+                           placeholder="Password" />
+                <button class="btn btn-outline-secondary" type="button" @onclick="TogglePasswordVisibility">
+                    <i class="bi @PasswordToggleIcon" aria-hidden="true"></i>
+                </button>
+            </div>
+            <button class="btn btn-primary" type="submit">Login</button>
+        </EditForm>
     </div>
 }
 @if (!string.IsNullOrEmpty(jwtToken))


### PR DESCRIPTION
## Summary
- Wrap JWT login inputs in a Blazor `EditForm`
- Add username/password attributes and submit button

## Testing
- `dotnet build BlazorWP/BlazorWP.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b29d826a5883228d3275d2d34cf4ce