### PR TITLE
Add clipboard copy for JWT display

### DIFF
--- a/BlazorWP/Data/ClipboardJsInterop.cs
+++ b/BlazorWP/Data/ClipboardJsInterop.cs
@@ -1,0 +1,45 @@
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public class ClipboardJsInterop : IDisposable, IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private IJSObjectReference? _module;
+
+    public ClipboardJsInterop(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private async ValueTask<IJSObjectReference> GetModuleAsync()
+    {
+        if (_module == null)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/clipboard.js");
+        }
+        return _module;
+    }
+
+    public async ValueTask CopyAsync(string text)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("copy", text);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module != null)
+        {
+            await _module.DisposeAsync();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_module != null)
+        {
+            _module.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+}

--- a/BlazorWP/Pages/Home.razor
+++ b/BlazorWP/Pages/Home.razor
@@ -51,17 +51,24 @@
 }
 @if (!string.IsNullOrEmpty(jwtToken))
 {
-    <div class="mt-2">
-        <strong>JWT:</strong> <code>@jwtToken</code>
-    </div>
-    @if (!string.IsNullOrEmpty(jwtDecoded))
-    {
-        <div class="mt-2">
-            <strong>JWT Payload:</strong>
-            <pre class="json-view">@jwtDecoded</pre>
-            <details class="mt-2">
-                <summary>Interpretation</summary>
-                <pre>
+    <div class="mt-3">
+        <label class="form-label">JWT</label>
+        <div class="input-group">
+            <span class="input-group-text">JWT</span>
+            <input class="form-control" readonly value="@jwtToken" title="@jwtToken" />
+            <button class="btn btn-outline-secondary" type="button" @onclick="CopyJwt">
+                <i class="bi bi-clipboard"></i>
+                <span class="d-none d-sm-inline ms-1">Copy</span>
+            </button>
+        </div>
+        @if (!string.IsNullOrEmpty(jwtDecoded))
+        {
+            <div class="mt-3">
+                <strong>JWT Payload:</strong>
+                <pre class="json-view">@jwtDecoded</pre>
+                <details class="mt-2">
+                    <summary>Interpretation</summary>
+                    <pre>
 This JSON is the payload of a JWT (JSON Web Token). Here’s what each field means:
 
 iss (Issuer):
@@ -72,8 +79,8 @@ Any service that trusts tokens from that URL can accept this one.
 iat (Issued At):
 A Unix timestamp (seconds since January 1 1970 UTC) indicating when the token was created.
 
-1750315403 → 2025-06-19 06:43:23 UTC  
-                 = 2025-06-19 15:43:23 JST  
+1750315403 → 2025-06-19 06:43:23 UTC
+                 = 2025-06-19 15:43:23 JST
 (Asia/Tokyo is UTC+9.)
 
 nbf (Not Before):
@@ -82,8 +89,8 @@ Tokens should not be considered valid before this time. In this case it’s iden
 exp (Expiration):
 When the token stops being valid.
 
-1750920203 → 2025-06-26 06:43:23 UTC  
-                 = 2025-06-26 15:43:23 JST  
+1750920203 → 2025-06-26 06:43:23 UTC
+                 = 2025-06-26 15:43:23 JST
 After that moment, any service should reject the token.
 
 data (Custom Claims):
@@ -95,10 +102,11 @@ so the token “knows” it refers to user #1 in your system.
 
 In plain language:
 This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 JST), becomes valid immediately, and stays valid until exactly one week later, 2025-06-26 06:43:23 UTC (15:43 JST). It carries a payload identifying “user 1.” Any service that sees it should verify its signature, check that “iss” matches the expected issuer, ensure the current time is between nbf and exp, and then trust that the bearer is user 1.
-                </pre>
-            </details>
-        </div>
-    }
+                    </pre>
+                </details>
+            </div>
+        }
+    </div>
 }
 @if (!string.IsNullOrEmpty(jwtError))
 {
@@ -208,6 +216,8 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
     private IConfiguration Config { get; set; } = default!;
     [Inject]
     private CredentialManagerJsInterop CredentialJs { get; set; } = default!;
+    [Inject]
+    private ClipboardJsInterop Clipboard { get; set; } = default!;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -524,6 +534,16 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
     private void TogglePasswordVisibility()
     {
         passwordVisible = !passwordVisible;
+    }
+
+    private async Task CopyJwt()
+    {
+        if (!string.IsNullOrEmpty(jwtToken))
+        {
+            await Clipboard.CopyAsync(jwtToken);
+            status = "JWT copied to clipboard.";
+            StateHasChanged();
+        }
     }
 
     private async Task JwtLoginAsync()

--- a/BlazorWP/Program.cs
+++ b/BlazorWP/Program.cs
@@ -30,6 +30,7 @@ namespace BlazorWP
             builder.Services.AddScoped<LocalStorageJsInterop>();
             builder.Services.AddScoped<SessionStorageJsInterop>();
             builder.Services.AddScoped<CredentialManagerJsInterop>();
+            builder.Services.AddScoped<ClipboardJsInterop>();
             builder.Services.AddScoped<WpMediaJsInterop>();
             builder.Services.AddScoped<WordPressApiService>();
 

--- a/BlazorWP/wwwroot/js/clipboard.js
+++ b/BlazorWP/wwwroot/js/clipboard.js
@@ -1,0 +1,17 @@
+export async function copy(text) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.style.position = 'fixed';
+  ta.style.opacity = '0';
+  document.body.appendChild(ta);
+  ta.select();
+  try {
+    document.execCommand('copy');
+  } finally {
+    document.body.removeChild(ta);
+  }
+}


### PR DESCRIPTION
## Summary
- Show JWT in Bootstrap input group with copy button
- Add ClipboardJsInterop service and JS module to copy token
- Register clipboard helper in DI container

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a5494e0c8322913b059d532b4ac0