### PR TITLE
Remove unused OAuth client configuration

### DIFF
--- a/BlazorWP/wwwroot/appsettings.json
+++ b/BlazorWP/wwwroot/appsettings.json
@@ -1,17 +1,5 @@
 {
-  "Authentication": {
-    "Google": {
-      "ClientId": "170092734657-7hub170g0k86v1a0n4h1g5ehfp81auke.apps.googleusercontent.com"
-    },
-    "GitHub": {
-      "ClientId": "Iv23liXKevTbbJRtbx9h"
-    },
-    "Line": {
-      "ClientId": "2007382036"
-    }
-  },
-    "WordPress": {
+  "WordPress": {
     "Url": "https://yasuaki.com"
   }
 }
-


### PR DESCRIPTION
## Summary
- drop GitHub, Google and Line OAuth settings from BlazorWP client config
- keep only WordPress URL for API integration

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a7c767248322ad7e7176ec5c1382