### PR TITLE
Enable English/Japanese language toggle

### DIFF
--- a/BlazorWP/BlazorWP.csproj
+++ b/BlazorWP/BlazorWP.csproj
@@ -5,6 +5,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>9ad1c7c4-0886-48a8-b74b-2567549501b3</UserSecretsId>
+    <InvariantGlobalization>false</InvariantGlobalization>
+    <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BlazorWP/Data/LanguageService.cs
+++ b/BlazorWP/Data/LanguageService.cs
@@ -1,0 +1,33 @@
+using System.Globalization;
+
+namespace BlazorWP.Data
+{
+    public class LanguageService
+    {
+        private CultureInfo _currentCulture = new("en-US");
+        public CultureInfo CurrentCulture => _currentCulture;
+
+        public event Action? OnChange;
+
+        public void SetCulture(string cultureCode)
+        {
+            var culture = new CultureInfo(cultureCode);
+            CultureInfo.DefaultThreadCurrentCulture = culture;
+            CultureInfo.DefaultThreadCurrentUICulture = culture;
+            _currentCulture = culture;
+            OnChange?.Invoke();
+        }
+
+        public void ToggleCulture()
+        {
+            if (_currentCulture.Name == "ja-JP")
+            {
+                SetCulture("en-US");
+            }
+            else
+            {
+                SetCulture("ja-JP");
+            }
+        }
+    }
+}

--- a/BlazorWP/Layout/NavMenu.razor
+++ b/BlazorWP/Layout/NavMenu.razor
@@ -1,9 +1,19 @@
-﻿<div class="top-row ps-3 navbar navbar-dark">
+@implements IDisposable
+@inject LanguageService LanguageService
+@inject IStringLocalizer<NavMenu> L
+
+<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="">BlazorWP</a>
-        <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
-            <span class="navbar-toggler-icon"></span>
-        </button>
+        <div class="ms-auto d-flex align-items-center">
+            <div class="form-check form-switch text-white me-2">
+                <input class="form-check-input" type="checkbox" role="switch" id="langSwitch" @onchange="() => LanguageService.ToggleCulture()" checked="@IsJapanese" />
+                <label class="form-check-label" for="langSwitch">@CurrentLanguageLabel</label>
+            </div>
+            <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+        </div>
     </div>
 </div>
 
@@ -11,62 +21,62 @@
     <nav class="nav flex-column">
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> Home
+                <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> @L["Home"]
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="counter">
-                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Counter
+                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> @L["Counter"]
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="weather">
-                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Weather"]
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="bootstrap-icons-demo">
-                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Icons Demo
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["IconsDemo"]
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="data-storage">
-                <span class="bi bi-database-fill-nav-menu" aria-hidden="true"></span> Data Storage
+                <span class="bi bi-database-fill-nav-menu" aria-hidden="true"></span> @L["DataStorage"]
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="edit">
-                <span class="bi bi-pencil-square" aria-hidden="true"></span> Edit
+                <span class="bi bi-pencil-square" aria-hidden="true"></span> @L["Edit"]
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="pcl-demo">
-                <span class="bi bi-plug-fill-nav-menu" aria-hidden="true"></span> PCL Demo
+                <span class="bi bi-plug-fill-nav-menu" aria-hidden="true"></span> @L["PclDemo"]
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="upload-pdf">
-                <span class="bi bi-upload" aria-hidden="true"></span> Upload PDF
+                <span class="bi bi-upload" aria-hidden="true"></span> @L["UploadPdf"]
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="approved-email-demo">
-                <span class="bi bi-envelope-fill" aria-hidden="true"></span> Approved Emails
+                <span class="bi bi-envelope-fill" aria-hidden="true"></span> @L["ApprovedEmails"]
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="media">
-                <span class="bi bi-image" aria-hidden="true"></span> Media Library
+                <span class="bi bi-image" aria-hidden="true"></span> @L["MediaLibrary"]
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="wp-users">
-                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> WP Users
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["WpUsers"]
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="diagnostics">
-                <span class="bi bi-gear-fill-nav-menu" aria-hidden="true"></span> Diagnostics
+                <span class="bi bi-gear-fill-nav-menu" aria-hidden="true"></span> @L["Diagnostics"]
             </NavLink>
         </div>
     </nav>
@@ -76,6 +86,19 @@
     private bool collapseNavMenu = true;
 
     private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
+
+    private bool IsJapanese => LanguageService.CurrentCulture.Name == "ja-JP";
+    private string CurrentLanguageLabel => L[IsJapanese ? "Japanese" : "English"];
+
+    protected override void OnInitialized()
+    {
+        LanguageService.OnChange += StateHasChanged;
+    }
+
+    public void Dispose()
+    {
+        LanguageService.OnChange -= StateHasChanged;
+    }
 
     private void ToggleNavMenu()
     {

--- a/BlazorWP/Pages/Home.razor
+++ b/BlazorWP/Pages/Home.razor
@@ -1,12 +1,13 @@
-﻿@page "/"
+@page "/"
 @using System.ComponentModel.DataAnnotations
+@inject IStringLocalizer<Home> L
 
-<PageTitle>Home</PageTitle>
+<PageTitle>@L["HomeTitle"]</PageTitle>
 
-<h1>WordPress analysis</h1>
+<h1>@L["WpAnalysis"]</h1>
 
 <div class="mb-3">
-    <label for="wpUrl" class="form-label">WordPress site URL</label>
+    <label for="wpUrl" class="form-label">@L["WordPressSiteUrl"]</label>
     <input id="wpUrl" list="siteSuggestions" class="form-control" @bind="userUrl" @bind:event="oninput" @onkeydown="HandleKeyDown" placeholder="https://example.com" />
     @if (knownSites.Any())
     {
@@ -18,7 +19,7 @@
         </datalist>
     }
 </div>
-<button class="btn btn-primary" @onclick="CheckApi">Check API</button>
+<button class="btn btn-primary" @onclick="CheckApi">@L["CheckApi"]</button>
 @if (!string.IsNullOrEmpty(verifiedEndpoint))
 {
     <button class="btn btn-secondary ms-2" @onclick="OpenLogin">Login to WordPress</button>

--- a/BlazorWP/Program.cs
+++ b/BlazorWP/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using PanoramicData.Blazor.Extensions;
+using System.Globalization;
 
 namespace BlazorWP
 {
@@ -33,12 +34,18 @@ namespace BlazorWP
             builder.Services.AddScoped<ClipboardJsInterop>();
             builder.Services.AddScoped<WpMediaJsInterop>();
             builder.Services.AddScoped<WordPressApiService>();
+            builder.Services.AddLocalization();
+            builder.Services.AddScoped<LanguageService>();
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();
 
             // 6) Now that the JSON has been loaded, enumerate via ILogger
             var config = host.Services.GetRequiredService<IConfiguration>();
+
+            // Set default culture
+            var languageService = host.Services.GetRequiredService<LanguageService>();
+            languageService.SetCulture("en-US");
 
             // 7) And finally run
             await host.RunAsync();

--- a/BlazorWP/Resources/Layout/NavMenu.ja.resx
+++ b/BlazorWP/Resources/Layout/NavMenu.ja.resx
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Home" xml:space="preserve"><value>ホーム</value></data>
+  <data name="Counter" xml:space="preserve"><value>カウンター</value></data>
+  <data name="Weather" xml:space="preserve"><value>天気</value></data>
+  <data name="IconsDemo" xml:space="preserve"><value>アイコンデモ</value></data>
+  <data name="DataStorage" xml:space="preserve"><value>データストレージ</value></data>
+  <data name="Edit" xml:space="preserve"><value>編集</value></data>
+  <data name="PclDemo" xml:space="preserve"><value>PCLデモ</value></data>
+  <data name="UploadPdf" xml:space="preserve"><value>PDFアップロード</value></data>
+  <data name="ApprovedEmails" xml:space="preserve"><value>承認済みメール</value></data>
+  <data name="MediaLibrary" xml:space="preserve"><value>メディアライブラリ</value></data>
+  <data name="WpUsers" xml:space="preserve"><value>WPユーザー</value></data>
+  <data name="Diagnostics" xml:space="preserve"><value>診断</value></data>
+  <data name="English" xml:space="preserve"><value>英語</value></data>
+  <data name="Japanese" xml:space="preserve"><value>日本語</value></data>
+</root>

--- a/BlazorWP/Resources/Layout/NavMenu.resx
+++ b/BlazorWP/Resources/Layout/NavMenu.resx
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Home" xml:space="preserve"><value>Home</value></data>
+  <data name="Counter" xml:space="preserve"><value>Counter</value></data>
+  <data name="Weather" xml:space="preserve"><value>Weather</value></data>
+  <data name="IconsDemo" xml:space="preserve"><value>Icons Demo</value></data>
+  <data name="DataStorage" xml:space="preserve"><value>Data Storage</value></data>
+  <data name="Edit" xml:space="preserve"><value>Edit</value></data>
+  <data name="PclDemo" xml:space="preserve"><value>PCL Demo</value></data>
+  <data name="UploadPdf" xml:space="preserve"><value>Upload PDF</value></data>
+  <data name="ApprovedEmails" xml:space="preserve"><value>Approved Emails</value></data>
+  <data name="MediaLibrary" xml:space="preserve"><value>Media Library</value></data>
+  <data name="WpUsers" xml:space="preserve"><value>WP Users</value></data>
+  <data name="Diagnostics" xml:space="preserve"><value>Diagnostics</value></data>
+  <data name="English" xml:space="preserve"><value>English</value></data>
+  <data name="Japanese" xml:space="preserve"><value>Japanese</value></data>
+</root>

--- a/BlazorWP/Resources/Pages/Home.ja.resx
+++ b/BlazorWP/Resources/Pages/Home.ja.resx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="HomeTitle" xml:space="preserve"><value>ホーム</value></data>
+  <data name="WpAnalysis" xml:space="preserve"><value>WordPress解析</value></data>
+  <data name="WordPressSiteUrl" xml:space="preserve"><value>WordPressサイトURL</value></data>
+  <data name="CheckApi" xml:space="preserve"><value>APIを確認</value></data>
+</root>

--- a/BlazorWP/Resources/Pages/Home.resx
+++ b/BlazorWP/Resources/Pages/Home.resx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="HomeTitle" xml:space="preserve"><value>Home</value></data>
+  <data name="WpAnalysis" xml:space="preserve"><value>WordPress analysis</value></data>
+  <data name="WordPressSiteUrl" xml:space="preserve"><value>WordPress site URL</value></data>
+  <data name="CheckApi" xml:space="preserve"><value>Check API</value></data>
+</root>

--- a/BlazorWP/_Imports.razor
+++ b/BlazorWP/_Imports.razor
@@ -16,3 +16,4 @@
 @using PanoramicData.Blazor.Arguments
 @using BlazorWP.Data
 @using Microsoft.Extensions.Configuration
+@using Microsoft.Extensions.Localization


### PR DESCRIPTION
## Summary
- add localization services and culture management
- translate navigation menu and home page
- add Bootstrap switch in header to toggle English/Japanese

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b5459e5c83228059f7628995324e