### PR TITLE
Fix language toggle not updating UI

### DIFF
--- a/BlazorWP/Data/LanguageService.cs
+++ b/BlazorWP/Data/LanguageService.cs
@@ -12,6 +12,8 @@ namespace BlazorWP.Data
         public void SetCulture(string cultureCode)
         {
             var culture = new CultureInfo(cultureCode);
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
             CultureInfo.DefaultThreadCurrentCulture = culture;
             CultureInfo.DefaultThreadCurrentUICulture = culture;
             _currentCulture = culture;

--- a/BlazorWP/Layout/MainLayout.razor
+++ b/BlazorWP/Layout/MainLayout.razor
@@ -2,6 +2,8 @@
 
 @implements IDisposable
 @implements IAsyncDisposable
+@using BlazorWP.Data
+@inject LanguageService LanguageService
 <div class="page">
     <div class="sidebar">
         <NavMenu />
@@ -49,6 +51,11 @@
     private bool hostInWp = true;
     private string? nonceMessage;
     private DotNetObjectReference<object>? _objRef;
+
+    protected override void OnInitialized()
+    {
+        LanguageService.OnChange += HandleLanguageChanged;
+    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -185,10 +192,16 @@
 
     public void Dispose()
     {
+        LanguageService.OnChange -= HandleLanguageChanged;
         if (_objRef != null)
         {
             EndpointSyncJs.UnregisterAsync().GetAwaiter().GetResult();
             _objRef.Dispose();
         }
+    }
+
+    private void HandleLanguageChanged()
+    {
+        InvokeAsync(StateHasChanged);
     }
 }

--- a/BlazorWP/Layout/NavMenu.razor
+++ b/BlazorWP/Layout/NavMenu.razor
@@ -8,7 +8,7 @@
         <a class="navbar-brand" href="">BlazorWP</a>
         <div class="ms-auto d-flex align-items-center">
             <div class="form-check form-switch text-white me-2">
-                <input class="form-check-input" type="checkbox" role="switch" id="langSwitch" @onchange="() => LanguageService.ToggleCulture()" checked="@IsJapanese" />
+                <input class="form-check-input" type="checkbox" role="switch" id="langSwitch" @bind="isJapanese" @bind:after="OnLanguageChanged" />
                 <label class="form-check-label" for="langSwitch">@CurrentLanguageLabel</label>
             </div>
             <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
@@ -88,17 +88,29 @@
 
     private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
 
-    private bool IsJapanese => LanguageService.CurrentCulture.Name == "ja-JP";
-    private string CurrentLanguageLabel => L[IsJapanese ? "Japanese" : "English"];
+    private bool isJapanese;
+    private string CurrentLanguageLabel => L[isJapanese ? "Japanese" : "English"];
 
     protected override void OnInitialized()
     {
-        LanguageService.OnChange += StateHasChanged;
+        isJapanese = LanguageService.CurrentCulture.Name == "ja-JP";
+        LanguageService.OnChange += HandleLanguageChanged;
+    }
+
+    private void HandleLanguageChanged()
+    {
+        isJapanese = LanguageService.CurrentCulture.Name == "ja-JP";
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void OnLanguageChanged()
+    {
+        LanguageService.SetCulture(isJapanese ? "ja-JP" : "en-US");
     }
 
     public void Dispose()
     {
-        LanguageService.OnChange -= StateHasChanged;
+        LanguageService.OnChange -= HandleLanguageChanged;
     }
 
     private void ToggleNavMenu()


### PR DESCRIPTION
## Summary
- ensure LanguageService updates CurrentCulture and CurrentUICulture
- convert NavMenu language switch to @bind with @bind:after and synchronize with LanguageService
- have MainLayout listen for language changes to refresh page content

## Testing
- `dotnet build BlazorWP/BlazorWP.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c05547d48322a3dd983594c39648