### PR TITLE
Ensure language service is registered as singleton

### DIFF
--- a/BlazorWP/Program.cs
+++ b/BlazorWP/Program.cs
@@ -37,8 +37,8 @@ namespace BlazorWP
             builder.Services.AddScoped<ClipboardJsInterop>();
             builder.Services.AddScoped<WpMediaJsInterop>();
             builder.Services.AddScoped<WordPressApiService>();
-            builder.Services.AddLocalization();
-            builder.Services.AddScoped<LanguageService>();
+            builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
+            builder.Services.AddSingleton<LanguageService>();
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();


### PR DESCRIPTION
## Summary
- Register localization resources path explicitly
- Use singleton `LanguageService` so culture change notifications are shared across components

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c9e9dd5c83228310fd8f5c090c57