### PR TITLE
Remove language switch UI

### DIFF
--- a/BlazorWP/Data/LanguageService.cs
+++ b/BlazorWP/Data/LanguageService.cs
@@ -7,8 +7,6 @@ namespace BlazorWP.Data
         private CultureInfo _currentCulture = new("en-US");
         public CultureInfo CurrentCulture => _currentCulture;
 
-        public event Action? OnChange;
-
         public void SetCulture(string cultureCode)
         {
             var culture = new CultureInfo(cultureCode);
@@ -17,19 +15,6 @@ namespace BlazorWP.Data
             CultureInfo.DefaultThreadCurrentCulture = culture;
             CultureInfo.DefaultThreadCurrentUICulture = culture;
             _currentCulture = culture;
-            OnChange?.Invoke();
-        }
-
-        public void ToggleCulture()
-        {
-            if (_currentCulture.Name == "ja-JP")
-            {
-                SetCulture("en-US");
-            }
-            else
-            {
-                SetCulture("ja-JP");
-            }
         }
     }
 }

--- a/BlazorWP/Layout/MainLayout.razor
+++ b/BlazorWP/Layout/MainLayout.razor
@@ -3,7 +3,6 @@
 @implements IDisposable
 @implements IAsyncDisposable
 @using BlazorWP.Data
-@inject LanguageService LanguageService
 <div class="page">
     <div class="sidebar">
         <NavMenu />
@@ -51,11 +50,6 @@
     private bool hostInWp = true;
     private string? nonceMessage;
     private DotNetObjectReference<object>? _objRef;
-
-    protected override void OnInitialized()
-    {
-        LanguageService.OnChange += HandleLanguageChanged;
-    }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -192,16 +186,10 @@
 
     public void Dispose()
     {
-        LanguageService.OnChange -= HandleLanguageChanged;
         if (_objRef != null)
         {
             EndpointSyncJs.UnregisterAsync().GetAwaiter().GetResult();
             _objRef.Dispose();
         }
-    }
-
-    private void HandleLanguageChanged()
-    {
-        InvokeAsync(StateHasChanged);
     }
 }

--- a/BlazorWP/Layout/NavMenu.razor
+++ b/BlazorWP/Layout/NavMenu.razor
@@ -1,16 +1,9 @@
-@using BlazorWP.Data
-@implements IDisposable
-@inject LanguageService LanguageService
 @inject IStringLocalizer<NavMenu> L
 
 <div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="">BlazorWP</a>
         <div class="ms-auto d-flex align-items-center">
-            <div class="form-check form-switch text-white me-2">
-                <input class="form-check-input" type="checkbox" role="switch" id="langSwitch" @bind="isJapanese" @bind:after="OnLanguageChanged" />
-                <label class="form-check-label" for="langSwitch">@CurrentLanguageLabel</label>
-            </div>
             <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
                 <span class="navbar-toggler-icon"></span>
             </button>
@@ -87,31 +80,6 @@
     private bool collapseNavMenu = true;
 
     private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
-
-    private bool isJapanese;
-    private string CurrentLanguageLabel => L[isJapanese ? "Japanese" : "English"];
-
-    protected override void OnInitialized()
-    {
-        isJapanese = LanguageService.CurrentCulture.Name == "ja-JP";
-        LanguageService.OnChange += HandleLanguageChanged;
-    }
-
-    private void HandleLanguageChanged()
-    {
-        isJapanese = LanguageService.CurrentCulture.Name == "ja-JP";
-        InvokeAsync(StateHasChanged);
-    }
-
-    private void OnLanguageChanged()
-    {
-        LanguageService.SetCulture(isJapanese ? "ja-JP" : "en-US");
-    }
-
-    public void Dispose()
-    {
-        LanguageService.OnChange -= HandleLanguageChanged;
-    }
 
     private void ToggleNavMenu()
     {


### PR DESCRIPTION
## Summary
- remove language toggle from navigation menu
- streamline language service to rely solely on URL parameter

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cf8111408322b9509e37b2cc6506