### PR TITLE
Expand localization to editor and user pages

### DIFF
--- a/BlazorWP/Pages/Edit.razor
+++ b/BlazorWP/Pages/Edit.razor
@@ -7,16 +7,17 @@
 @inject JwtService JwtService
 @inject LocalStorageJsInterop StorageJs
 @inject WordPressApiService Api
+@inject IStringLocalizer<Edit> L
 @implements IDisposable
 @implements IAsyncDisposable
 
-<PageTitle>Edit</PageTitle>
+<PageTitle>@L["EditTitle"]</PageTitle>
 
-<h1>Edit</h1>
+<h1>@L["EditTitle"]</h1>
 
 <div class="mb-2">
-    <button class="btn btn-sm btn-outline-secondary me-1" @onclick="ToggleControls">@(showControls ? "Hide Details" : "Show Details")</button>
-    <button class="btn btn-sm btn-outline-secondary me-1" @onclick="ToggleTable">@(showTable ? "Hide Posts" : "Show Posts")</button>
+    <button class="btn btn-sm btn-outline-secondary me-1" @onclick="ToggleControls">@(showControls ? L["HideDetails"] : L["ShowDetails"])</button>
+    <button class="btn btn-sm btn-outline-secondary me-1" @onclick="ToggleTable">@(showTable ? L["HidePosts"] : L["ShowPosts"])</button>
 </div>
 
 @if (showControls)
@@ -27,15 +28,15 @@
     }
 
     <div class="mb-3">
-        <label class="form-label" for="postTitle">Title</label>
+        <label class="form-label" for="postTitle">@L["Title"]</label>
         <input id="postTitle" class="form-control" @bind="postTitle" @bind:event="oninput" @bind:after="OnTitleChanged" />
     </div>
     @if (mediaSources.Any())
     {
         <div class="mb-3">
-            <label class="form-label" for="mediaSource">Media Source</label>
+            <label class="form-label" for="mediaSource">@L["MediaSource"]</label>
             <select id="mediaSource" class="form-select" @bind="selectedMediaSource" @bind:after="OnMediaSourceChanged">
-                <option value="">-- choose media site --</option>
+                <option value="">@L["ChooseMediaSite"]</option>
                 @foreach (var site in mediaSources)
                 {
                     <option value="@site">@site</option>
@@ -46,7 +47,7 @@
     @if (categories.Any())
     {
         <div class="mb-3">
-            <label class="form-label">Categories</label>
+            <label class="form-label">@L["Categories"]</label>
             <div>
                 @foreach (var cat in categories)
                 {
@@ -60,24 +61,24 @@
     }
 
     <div class="d-flex align-items-center mb-2">
-        <button class="btn btn-success me-2" @onclick="NewPost">New</button>
+        <button class="btn btn-success me-2" @onclick="NewPost">@L["New"]</button>
         @if (ShowSaveDraftButton)
         {
-            <button class="btn btn-primary me-2" @onclick="SaveDraft" disabled="@(!CanSaveDraft)">Save Draft</button>
+            <button class="btn btn-primary me-2" @onclick="SaveDraft" disabled="@(!CanSaveDraft)">@L["SaveDraft"]</button>
         }
         @if (ShowSubmitForReviewButton)
         {
-            <button class="btn btn-secondary me-2" @onclick="SubmitForReview">Submit for Review</button>
+            <button class="btn btn-secondary me-2" @onclick="SubmitForReview">@L["SubmitForReview"]</button>
         }
         @if (showRetractReview)
         {
-            <button class="btn btn-warning me-2" @onclick="RetractReview">Retract Review</button>
+            <button class="btn btn-warning me-2" @onclick="RetractReview">@L["RetractReview"]</button>
         }
-        <button class="btn btn-danger me-2" @onclick="CloseEditor">Close</button>
+        <button class="btn btn-danger me-2" @onclick="CloseEditor">@L["Close"]</button>
         <div class="ms-auto d-flex align-items-center">
 
     <div class="d-flex align-items-center mb-2">
-        <button class="btn btn-sm btn-outline-secondary me-2" @onclick="RefreshPosts" disabled="@isLoading">Refresh</button>
+        <button class="btn btn-sm btn-outline-secondary me-2" @onclick="RefreshPosts" disabled="@isLoading">@L["Refresh"]</button>
         <select class="form-select form-select-sm w-auto me-2" @bind="selectedRefreshCount">
             @foreach (var opt in refreshOptions)
             {
@@ -86,18 +87,18 @@
         </select>
         <div class="form-check form-switch me-2">
             <input class="form-check-input" type="checkbox" id="showTrashedToggle" @bind="showTrashed" @bind:after="OnShowTrashedChanged" />
-            <label class="form-check-label" for="showTrashedToggle">Include trashed articles</label>
+            <label class="form-check-label" for="showTrashedToggle">@L["IncludeTrashedArticles"]</label>
         </div>
-        <span class="ms-2">@DisplayCount articles</span>
+        <span class="ms-2">@string.Format(L["ArticlesCount"], DisplayCount)</span>
     </div>
-            <span><strong>Status:</strong> @(isDirty ? "Dirty" : "Clean")</span>
+            <span><strong>@L["StatusLabel"]</strong> @(isDirty ? L["Dirty"] : L["Clean"])</span>
         </div>
     </div>
 }
 
 @if (posts == null)
 {
-    <p><em>Loading posts...</em></p>
+    <p><em>@L["LoadingPosts"]</em></p>
 }
 else if (showTable)
 {
@@ -105,12 +106,12 @@ else if (showTable)
         <table class="table table-hover">
             <thead>
                 <tr>
-                    <th>Id</th>
-                    <th>Title</th>
-                    <th>Author</th>
-                    <th>Status</th>
-                    <th>Publication Date</th>
-                    <th>Change Status</th>
+                    <th>@L["Id"]</th>
+                    <th>@L["Title"]</th>
+                    <th>@L["Author"]</th>
+                    <th>@L["Status"]</th>
+                    <th>@L["PublicationDate"]</th>
+                    <th>@L["ChangeStatus"]</th>
                 </tr>
             </thead>
             <tbody>

--- a/BlazorWP/Pages/Home.razor
+++ b/BlazorWP/Pages/Home.razor
@@ -22,8 +22,8 @@
 <button class="btn btn-primary" @onclick="CheckApi">@L["CheckApi"]</button>
 @if (!string.IsNullOrEmpty(verifiedEndpoint))
 {
-    <button class="btn btn-secondary ms-2" @onclick="OpenLogin">Login to WordPress</button>
-    <button class="btn btn-info ms-2" @onclick="ToggleJwtLogin">JWT Login</button>
+    <button class="btn btn-secondary ms-2" @onclick="OpenLogin">@L["LoginToWordPress"]</button>
+    <button class="btn btn-info ms-2" @onclick="ToggleJwtLogin">@L["JwtLogin"]</button>
 }
 @if (showJwtLogin && !string.IsNullOrEmpty(verifiedEndpoint))
 {
@@ -34,41 +34,41 @@
                        @bind-Value="jwtLoginModel.Username"
                        name="username"
                        autocomplete="username"
-                       placeholder="Username" />
+                       placeholder="@L["Username"]" />
             <div class="input-group mb-2">
                 <InputText class="form-control"
                            type="@PasswordInputType"
                            @bind-Value="jwtLoginModel.Password"
                            name="password"
                            autocomplete="current-password"
-                           placeholder="Password" />
+                           placeholder="@L["Password"]" />
                 <button class="btn btn-outline-secondary" type="button" @onclick="TogglePasswordVisibility">
                     <i class="bi @PasswordToggleIcon" aria-hidden="true"></i>
                 </button>
             </div>
-            <button class="btn btn-primary" type="submit">Login</button>
+            <button class="btn btn-primary" type="submit">@L["Login"]</button>
         </EditForm>
     </div>
 }
 @if (!string.IsNullOrEmpty(jwtToken))
 {
     <div class="mt-3">
-        <label class="form-label">JWT</label>
+        <label class="form-label">@L["Jwt"]</label>
         <div class="input-group">
-            <span class="input-group-text">JWT</span>
+            <span class="input-group-text">@L["Jwt"]</span>
             <input class="form-control" readonly value="@jwtToken" title="@jwtToken" />
             <button class="btn btn-outline-secondary" type="button" @onclick="CopyJwt">
                 <i class="bi bi-clipboard"></i>
-                <span class="d-none d-sm-inline ms-1">Copy</span>
+                <span class="d-none d-sm-inline ms-1">@L["Copy"]</span>
             </button>
         </div>
         @if (!string.IsNullOrEmpty(jwtDecoded))
         {
             <div class="mt-3">
-                <strong>JWT Payload:</strong>
+                <strong>@L["JwtPayload"]</strong>
                 <pre class="json-view">@jwtDecoded</pre>
                 <details class="mt-2">
-                    <summary>Interpretation</summary>
+                    <summary>@L["Interpretation"]</summary>
                     <pre>
 This JSON is the payload of a JWT (JSON Web Token). Here’s what each field means:
 

--- a/BlazorWP/Pages/WpUsers.razor
+++ b/BlazorWP/Pages/WpUsers.razor
@@ -1,22 +1,24 @@
 @page "/wp-users"
 @using WordPressPCL
 @using WordPressPCL.Models
+@using Microsoft.AspNetCore.Components
 @inject JwtService JwtService
 @inject WordPressApiService Api
+@inject IStringLocalizer<WpUsers> L
 
-<PageTitle>WordPress Users</PageTitle>
+<PageTitle>@L["WordPressUsersTitle"]</PageTitle>
 
 @if (client == null)
 {
-    <p>No WordPress endpoint verified. Visit <NavLink href="/">Home</NavLink> first.</p>
+    <p>@((MarkupString)string.Format(L["NoEndpoint"], $"<NavLink href=\"/\">{L["Home"]}</NavLink>"))</p>
 }
 else if (users == null && string.IsNullOrEmpty(error))
 {
-    <p><em>Loading...</em></p>
+    <p><em>@L["Loading"]</em></p>
 }
 else if (!string.IsNullOrEmpty(error))
 {
-    <p class="text-danger">Error: @error</p>
+    <p class="text-danger">@L["Error", error]</p>
 }
 else
 {
@@ -36,13 +38,13 @@ else
             @if (selectedUser != null)
             {
                 <h3>@selectedUser.Name</h3>
-                <p><strong>Email:</strong> @selectedUser.Email</p>
-                <p><strong>Slug:</strong> @selectedUser.Slug</p>
-                <p><strong>Link:</strong> <a href="@selectedUser.Link" target="_blank">@selectedUser.Link</a></p>
+                <p><strong>@L["EmailLabel"]</strong> @selectedUser.Email</p>
+                <p><strong>@L["SlugLabel"]</strong> @selectedUser.Slug</p>
+                <p><strong>@L["LinkLabel"]</strong> <a href="@selectedUser.Link" target="_blank">@selectedUser.Link</a></p>
             }
             else
             {
-                <p>Select a user from the sidebar.</p>
+                <p>@L["SelectUserFromSidebar"]</p>
             }
         </div>
     </div>

--- a/BlazorWP/Resources/Pages/Edit.ja.resx
+++ b/BlazorWP/Resources/Pages/Edit.ja.resx
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="EditTitle" xml:space="preserve"><value>編集</value></data>
+  <data name="HideDetails" xml:space="preserve"><value>詳細を隠す</value></data>
+  <data name="ShowDetails" xml:space="preserve"><value>詳細を表示</value></data>
+  <data name="HidePosts" xml:space="preserve"><value>投稿を隠す</value></data>
+  <data name="ShowPosts" xml:space="preserve"><value>投稿を表示</value></data>
+  <data name="Title" xml:space="preserve"><value>タイトル</value></data>
+  <data name="MediaSource" xml:space="preserve"><value>メディアソース</value></data>
+  <data name="ChooseMediaSite" xml:space="preserve"><value>-- メディアサイトを選択 --</value></data>
+  <data name="Categories" xml:space="preserve"><value>カテゴリー</value></data>
+  <data name="New" xml:space="preserve"><value>新規</value></data>
+  <data name="SaveDraft" xml:space="preserve"><value>下書きを保存</value></data>
+  <data name="SubmitForReview" xml:space="preserve"><value>レビューに提出</value></data>
+  <data name="RetractReview" xml:space="preserve"><value>レビューを撤回</value></data>
+  <data name="Close" xml:space="preserve"><value>閉じる</value></data>
+  <data name="Refresh" xml:space="preserve"><value>更新</value></data>
+  <data name="IncludeTrashedArticles" xml:space="preserve"><value>ゴミ箱の記事を含める</value></data>
+  <data name="ArticlesCount" xml:space="preserve"><value>{0} 件の記事</value></data>
+  <data name="StatusLabel" xml:space="preserve"><value>状態:</value></data>
+  <data name="Dirty" xml:space="preserve"><value>未保存</value></data>
+  <data name="Clean" xml:space="preserve"><value>保存済み</value></data>
+  <data name="LoadingPosts" xml:space="preserve"><value>投稿を読み込み中...</value></data>
+  <data name="Id" xml:space="preserve"><value>ID</value></data>
+  <data name="Author" xml:space="preserve"><value>作成者</value></data>
+  <data name="Status" xml:space="preserve"><value>状態</value></data>
+  <data name="PublicationDate" xml:space="preserve"><value>公開日</value></data>
+  <data name="ChangeStatus" xml:space="preserve"><value>状態を変更</value></data>
+</root>

--- a/BlazorWP/Resources/Pages/Edit.resx
+++ b/BlazorWP/Resources/Pages/Edit.resx
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="EditTitle" xml:space="preserve"><value>Edit</value></data>
+  <data name="HideDetails" xml:space="preserve"><value>Hide Details</value></data>
+  <data name="ShowDetails" xml:space="preserve"><value>Show Details</value></data>
+  <data name="HidePosts" xml:space="preserve"><value>Hide Posts</value></data>
+  <data name="ShowPosts" xml:space="preserve"><value>Show Posts</value></data>
+  <data name="Title" xml:space="preserve"><value>Title</value></data>
+  <data name="MediaSource" xml:space="preserve"><value>Media Source</value></data>
+  <data name="ChooseMediaSite" xml:space="preserve"><value>-- choose media site --</value></data>
+  <data name="Categories" xml:space="preserve"><value>Categories</value></data>
+  <data name="New" xml:space="preserve"><value>New</value></data>
+  <data name="SaveDraft" xml:space="preserve"><value>Save Draft</value></data>
+  <data name="SubmitForReview" xml:space="preserve"><value>Submit for Review</value></data>
+  <data name="RetractReview" xml:space="preserve"><value>Retract Review</value></data>
+  <data name="Close" xml:space="preserve"><value>Close</value></data>
+  <data name="Refresh" xml:space="preserve"><value>Refresh</value></data>
+  <data name="IncludeTrashedArticles" xml:space="preserve"><value>Include trashed articles</value></data>
+  <data name="ArticlesCount" xml:space="preserve"><value>{0} articles</value></data>
+  <data name="StatusLabel" xml:space="preserve"><value>Status:</value></data>
+  <data name="Dirty" xml:space="preserve"><value>Dirty</value></data>
+  <data name="Clean" xml:space="preserve"><value>Clean</value></data>
+  <data name="LoadingPosts" xml:space="preserve"><value>Loading posts...</value></data>
+  <data name="Id" xml:space="preserve"><value>Id</value></data>
+  <data name="Author" xml:space="preserve"><value>Author</value></data>
+  <data name="Status" xml:space="preserve"><value>Status</value></data>
+  <data name="PublicationDate" xml:space="preserve"><value>Publication Date</value></data>
+  <data name="ChangeStatus" xml:space="preserve"><value>Change Status</value></data>
+</root>

--- a/BlazorWP/Resources/Pages/Home.ja.resx
+++ b/BlazorWP/Resources/Pages/Home.ja.resx
@@ -4,4 +4,13 @@
   <data name="WpAnalysis" xml:space="preserve"><value>WordPress解析</value></data>
   <data name="WordPressSiteUrl" xml:space="preserve"><value>WordPressサイトURL</value></data>
   <data name="CheckApi" xml:space="preserve"><value>APIを確認</value></data>
+  <data name="LoginToWordPress" xml:space="preserve"><value>WordPress にログイン</value></data>
+  <data name="JwtLogin" xml:space="preserve"><value>JWT ログイン</value></data>
+  <data name="Username" xml:space="preserve"><value>ユーザー名</value></data>
+  <data name="Password" xml:space="preserve"><value>パスワード</value></data>
+  <data name="Login" xml:space="preserve"><value>ログイン</value></data>
+  <data name="Jwt" xml:space="preserve"><value>JWT</value></data>
+  <data name="Copy" xml:space="preserve"><value>コピー</value></data>
+  <data name="JwtPayload" xml:space="preserve"><value>JWT ペイロード:</value></data>
+  <data name="Interpretation" xml:space="preserve"><value>解釈</value></data>
 </root>

--- a/BlazorWP/Resources/Pages/Home.resx
+++ b/BlazorWP/Resources/Pages/Home.resx
@@ -4,4 +4,13 @@
   <data name="WpAnalysis" xml:space="preserve"><value>WordPress analysis</value></data>
   <data name="WordPressSiteUrl" xml:space="preserve"><value>WordPress site URL</value></data>
   <data name="CheckApi" xml:space="preserve"><value>Check API</value></data>
+  <data name="LoginToWordPress" xml:space="preserve"><value>Login to WordPress</value></data>
+  <data name="JwtLogin" xml:space="preserve"><value>JWT Login</value></data>
+  <data name="Username" xml:space="preserve"><value>Username</value></data>
+  <data name="Password" xml:space="preserve"><value>Password</value></data>
+  <data name="Login" xml:space="preserve"><value>Login</value></data>
+  <data name="Jwt" xml:space="preserve"><value>JWT</value></data>
+  <data name="Copy" xml:space="preserve"><value>Copy</value></data>
+  <data name="JwtPayload" xml:space="preserve"><value>JWT Payload:</value></data>
+  <data name="Interpretation" xml:space="preserve"><value>Interpretation</value></data>
 </root>

--- a/BlazorWP/Resources/Pages/WpUsers.ja.resx
+++ b/BlazorWP/Resources/Pages/WpUsers.ja.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="WordPressUsersTitle" xml:space="preserve"><value>WordPressユーザー</value></data>
+  <data name="NoEndpoint" xml:space="preserve"><value>WordPressエンドポイントが確認されていません。まず {0} を訪れてください。</value></data>
+  <data name="Home" xml:space="preserve"><value>ホーム</value></data>
+  <data name="Loading" xml:space="preserve"><value>読み込み中...</value></data>
+  <data name="Error" xml:space="preserve"><value>エラー: {0}</value></data>
+  <data name="EmailLabel" xml:space="preserve"><value>メール:</value></data>
+  <data name="SlugLabel" xml:space="preserve"><value>スラッグ:</value></data>
+  <data name="LinkLabel" xml:space="preserve"><value>リンク:</value></data>
+  <data name="SelectUserFromSidebar" xml:space="preserve"><value>サイドバーからユーザーを選択してください。</value></data>
+</root>

--- a/BlazorWP/Resources/Pages/WpUsers.resx
+++ b/BlazorWP/Resources/Pages/WpUsers.resx
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="WordPressUsersTitle" xml:space="preserve"><value>WordPress Users</value></data>
+  <data name="NoEndpoint" xml:space="preserve"><value>No WordPress endpoint verified. Visit {0} first.</value></data>
+  <data name="Home" xml:space="preserve"><value>Home</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading...</value></data>
+  <data name="Error" xml:space="preserve"><value>Error: {0}</value></data>
+  <data name="EmailLabel" xml:space="preserve"><value>Email:</value></data>
+  <data name="SlugLabel" xml:space="preserve"><value>Slug:</value></data>
+  <data name="LinkLabel" xml:space="preserve"><value>Link:</value></data>
+  <data name="SelectUserFromSidebar" xml:space="preserve"><value>Select a user from the sidebar.</value></data>
+</root>


### PR DESCRIPTION
## Summary
- replace hard-coded strings on Edit page with localized resources
- translate WordPress Users listing and add resource files for English and Japanese

## Testing
- `dotnet build BlazorWP/BlazorWP.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2d1ad0ba48322b4a80765c7a23c56