### PR TITLE
refactor: use DI for nonce retrieval

### DIFF
--- a/BlazorWP/Data/AuthMessageHandler.cs
+++ b/BlazorWP/Data/AuthMessageHandler.cs
@@ -1,5 +1,4 @@
 using System.Net.Http.Headers;
-using Microsoft.JSInterop;
 
 namespace BlazorWP;
 
@@ -7,14 +6,14 @@ public class AuthMessageHandler : DelegatingHandler
 {
     private readonly JwtService _jwtService;
     private readonly LocalStorageJsInterop _storage;
-    private readonly WpNonceJsInterop _nonceJs;
+    private readonly INonceService _nonceService;
     private const string HostInWpKey = "hostInWp";
 
-    public AuthMessageHandler(JwtService jwtService, LocalStorageJsInterop storage, WpNonceJsInterop nonceJs)
+    public AuthMessageHandler(JwtService jwtService, LocalStorageJsInterop storage, INonceService nonceService)
     {
         _jwtService = jwtService;
         _storage = storage;
-        _nonceJs = nonceJs;
+        _nonceService = nonceService;
         InnerHandler = new HttpClientHandler();
     }
 
@@ -38,7 +37,7 @@ public class AuthMessageHandler : DelegatingHandler
 
         if (useNonce)
         {
-            var nonce = await _nonceJs.GetNonceAsync();
+            var nonce = await _nonceService.GetNonceAsync(cancellationToken);
             if (!string.IsNullOrWhiteSpace(nonce))
             {
                 if (!ShouldSkipAuth(request))

--- a/BlazorWP/Data/NonceService.cs
+++ b/BlazorWP/Data/NonceService.cs
@@ -1,0 +1,29 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BlazorWP;
+
+public interface INonceService
+{
+    ValueTask<string?> GetNonceAsync(CancellationToken cancellationToken = default);
+}
+
+public class NonceService : INonceService
+{
+    private readonly WpNonceJsInterop _nonceJs;
+    private string? _nonce;
+
+    public NonceService(WpNonceJsInterop nonceJs)
+    {
+        _nonceJs = nonceJs;
+    }
+
+    public async ValueTask<string?> GetNonceAsync(CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(_nonce))
+        {
+            _nonce = await _nonceJs.GetNonceAsync();
+        }
+        return _nonce;
+    }
+}

--- a/BlazorWP/Layout/MainLayout.razor
+++ b/BlazorWP/Layout/MainLayout.razor
@@ -22,10 +22,6 @@
                 <input class="form-check-input" type="checkbox" id="hostInWpToggle" @bind="hostInWp" @bind:after="OnHostInWpChanged" />
                 <label class="form-check-label" for="hostInWpToggle">Hosted on WP</label>
             </div>
-            @if (hostInWp)
-            {
-                <span class="ms-2">Nonce: @nonceMessage</span>
-            }
         </div>
 
         <article class="content px-4">
@@ -38,8 +34,6 @@
     [Inject]
     private LocalStorageJsInterop StorageJs { get; set; } = default!;
     [Inject]
-    private WpNonceJsInterop NonceJs { get; set; } = default!;
-    [Inject]
     private WpEndpointSyncJsInterop EndpointSyncJs { get; set; } = default!;
     [Inject]
     private IConfiguration Config { get; set; } = default!;
@@ -48,7 +42,6 @@
     private string? currentUsername;
     private const string HostInWpKey = "hostInWp";
     private bool hostInWp = true;
-    private string? nonceMessage;
     private DotNetObjectReference<object>? _objRef;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -86,24 +79,13 @@
         {
             hostInWp = hostVal;
             changed = true;
-            if (hostInWp)
-            {
-                await FetchNonce();
-            }
-            else
-            {
-                nonceMessage = null;
-            }
         }
 
         if (firstRender)
         {
             _objRef = DotNetObjectReference.Create<object>(this);
             await EndpointSyncJs.RegisterAsync(_objRef);
-            if (hostInWp)
-            {
-                await FetchNonce();
-            }
+            // nonce fetched automatically when requests are made
         }
 
         if (changed)
@@ -149,29 +131,6 @@
     private async Task OnHostInWpChanged()
     {
         await StorageJs.SetItemAsync(HostInWpKey, hostInWp.ToString().ToLowerInvariant());
-        if (hostInWp)
-        {
-            await FetchNonce();
-        }
-        else
-        {
-            nonceMessage = null;
-            await InvokeAsync(StateHasChanged);
-        }
-    }
-
-    private async Task FetchNonce()
-    {
-        nonceMessage = "Loading...";
-        try
-        {
-            var nonce = await NonceJs.GetNonceAsync();
-            nonceMessage = !string.IsNullOrEmpty(nonce) ? nonce : "Could not retrieve nonce";
-        }
-        catch
-        {
-            nonceMessage = "Could not retrieve nonce";
-        }
         await InvokeAsync(StateHasChanged);
     }
 

--- a/BlazorWP/Program.cs
+++ b/BlazorWP/Program.cs
@@ -30,6 +30,7 @@ namespace BlazorWP
             builder.Services.AddScoped<JwtService>();
             builder.Services.AddScoped<UploadPdfJsInterop>();
             builder.Services.AddScoped<WpNonceJsInterop>();
+            builder.Services.AddScoped<INonceService, NonceService>();
             builder.Services.AddScoped<WpEndpointSyncJsInterop>();
             builder.Services.AddScoped<LocalStorageJsInterop>();
             builder.Services.AddScoped<SessionStorageJsInterop>();


### PR DESCRIPTION
## Summary
- add scoped NonceService for retrieving and caching WordPress nonce
- inject NonceService into AuthMessageHandler
- remove nonce fetching logic from MainLayout

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d18890348322a12d00c81e1c9124