### PR TITLE
Switch to appmode parameter

### DIFF
--- a/BlazorWP/Data/AppFlags.cs
+++ b/BlazorWP/Data/AppFlags.cs
@@ -1,12 +1,18 @@
 namespace BlazorWP.Data
 {
+    public enum AppMode
+    {
+        Full,
+        Basic
+    }
+
     public class AppFlags
     {
-        public bool Basic { get; private set; }
+        public AppMode Mode { get; private set; } = AppMode.Full;
 
-        public void SetBasic(bool value)
+        public void SetAppMode(AppMode mode)
         {
-            Basic = value;
+            Mode = mode;
         }
     }
 }

--- a/BlazorWP/Layout/MainLayout.razor
+++ b/BlazorWP/Layout/MainLayout.razor
@@ -28,7 +28,7 @@
             }
             <!-- 🔹 show Basic/Full mode -->
             <span class="badge bg-info ms-3">
-                @(Flags.Basic ? "Basic mode" : "Full mode")
+                @(Flags.Mode == AppMode.Basic ? "Basic mode" : "Full mode")
             </span>
         </div>
 


### PR DESCRIPTION
## Summary
- Track application mode with a new `AppMode` enum
- Display active app mode in the layout using `Flags.Mode`
- Parse and normalize `appmode` query parameter instead of boolean `basic`

## Testing
- `dotnet build BlazorWP/BlazorWP.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6765b5fd08322bf6e516b8d707316