### PR TITLE
Fix AppFlags page injection conflict

### DIFF
--- a/BlazorWP/Pages/AppFlags.razor
+++ b/BlazorWP/Pages/AppFlags.razor
@@ -1,6 +1,6 @@
 @page "/appflags"
 @using BlazorWP.Data
-@inject AppFlags Flags
+@inject BlazorWP.Data.AppFlags Flags
 
 <PageTitle>App Flags</PageTitle>
 


### PR DESCRIPTION
## Summary
- Fully qualify AppFlags service type to avoid collision with component name

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b67cbd0b04832287abb1eb64e7af77