### PR TITLE
feat: add language flag to App Flags page

### DIFF
--- a/BlazorWP/Data/AppFlags.cs
+++ b/BlazorWP/Data/AppFlags.cs
@@ -12,10 +12,17 @@ namespace BlazorWP.Data
         Nonce
     }
 
+    public enum Language
+    {
+        English,
+        Japanese
+    }
+
     public class AppFlags
     {
         public AppMode Mode { get; private set; } = AppMode.Full;
         public AuthType Auth { get; private set; } = AuthType.Jwt;
+        public Language Language { get; private set; } = Language.English;
 
         public void SetAppMode(AppMode mode)
         {
@@ -25,6 +32,11 @@ namespace BlazorWP.Data
         public void SetAuthMode(AuthType auth)
         {
             Auth = auth;
+        }
+
+        public void SetLanguage(Language language)
+        {
+            Language = language;
         }
     }
 }

--- a/BlazorWP/Pages/AppFlags.razor
+++ b/BlazorWP/Pages/AppFlags.razor
@@ -34,6 +34,16 @@
                 }
             </td>
         </tr>
+        <tr>
+            <td>Language</td>
+            <td>
+                @foreach (Language lang in Enum.GetValues<Language>())
+                {
+                    var active = Flags.Language == lang;
+                    <span class="badge @(active ? "bg-primary" : "bg-secondary") me-1">@lang</span>
+                }
+            </td>
+        </tr>
     </tbody>
 </table>
 

--- a/BlazorWP/Program.cs
+++ b/BlazorWP/Program.cs
@@ -105,6 +105,7 @@ namespace BlazorWP
 
             var culture = lang == "ja" ? "ja-JP" : "en-US";
             languageService.SetCulture(culture);
+            flags.SetLanguage(lang == "ja" ? Language.Japanese : Language.English);
 
             var needsNormalization =
                 !queryParams.TryGetValue("lang", out var existingLang) ||


### PR DESCRIPTION
## Summary
- track current language in `AppFlags` service
- show available languages on App Flags page
- record language flag based on query parameter

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b681eeb0f8832293e804d50a9da6a8