### PR TITLE
Hide advanced menu items in basic mode

### DIFF
--- a/BlazorWP/Layout/NavMenu.razor
+++ b/BlazorWP/Layout/NavMenu.razor
@@ -1,4 +1,6 @@
+@using BlazorWP.Data
 @inject IStringLocalizer<NavMenu> L
+@inject AppFlags Flags
 
 <div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
@@ -18,21 +20,24 @@
                 <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> @L["Home"]
             </NavLink>
         </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="counter">
-                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> @L["Counter"]
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="weather">
-                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Weather"]
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="bootstrap-icons-demo">
-                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["IconsDemo"]
-            </NavLink>
-        </div>
+        @if (Flags.Mode != AppMode.Basic)
+        {
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="counter">
+                    <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> @L["Counter"]
+                </NavLink>
+            </div>
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="weather">
+                    <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["Weather"]
+                </NavLink>
+            </div>
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="bootstrap-icons-demo">
+                    <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["IconsDemo"]
+                </NavLink>
+            </div>
+        }
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="data-storage">
                 <span class="bi bi-database-fill-nav-menu" aria-hidden="true"></span> @L["DataStorage"]
@@ -43,11 +48,14 @@
                 <span class="bi bi-pencil-square" aria-hidden="true"></span> @L["Edit"]
             </NavLink>
         </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="pcl-demo">
-                <span class="bi bi-plug-fill-nav-menu" aria-hidden="true"></span> @L["PclDemo"]
-            </NavLink>
-        </div>
+        @if (Flags.Mode != AppMode.Basic)
+        {
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="pcl-demo">
+                    <span class="bi bi-plug-fill-nav-menu" aria-hidden="true"></span> @L["PclDemo"]
+                </NavLink>
+            </div>
+        }
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="upload-pdf">
                 <span class="bi bi-upload" aria-hidden="true"></span> @L["UploadPdf"]
@@ -68,16 +76,19 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> @L["WpUsers"]
             </NavLink>
         </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="appflags">
-                <span class="bi bi-flag" aria-hidden="true"></span> @L["AppFlags"]
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="diagnostics">
-                <span class="bi bi-gear-fill-nav-menu" aria-hidden="true"></span> @L["Diagnostics"]
-            </NavLink>
-        </div>
+        @if (Flags.Mode != AppMode.Basic)
+        {
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="appflags">
+                    <span class="bi bi-flag" aria-hidden="true"></span> @L["AppFlags"]
+                </NavLink>
+            </div>
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="diagnostics">
+                    <span class="bi bi-gear-fill-nav-menu" aria-hidden="true"></span> @L["Diagnostics"]
+                </NavLink>
+            </div>
+        }
     </nav>
 </div>
 


### PR DESCRIPTION
## Summary
- Inject `AppFlags` into `NavMenu`
- Hide Counter, Weather, Icon Demo, PCL Demo, App Flags, and Diagnostics links when application mode is Basic

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b695ac08488322bbf11da32525a03e