### PR TITLE
Refresh entire app when AppFlags change

### DIFF
--- a/BlazorWP/App.razor
+++ b/BlazorWP/App.razor
@@ -1,4 +1,7 @@
-﻿<Router AppAssembly="@typeof(App).Assembly">
+@inject BlazorWP.Data.AppFlags Flags
+@implements IDisposable
+
+<Router AppAssembly="@typeof(App).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
         <FocusOnNavigate RouteData="@routeData" Selector="h1" />
@@ -10,3 +13,21 @@
         </LayoutView>
     </NotFound>
 </Router>
+
+@code {
+    protected override void OnInitialized()
+    {
+        Flags.OnChange += HandleFlagsChanged;
+    }
+
+    private void HandleFlagsChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        Flags.OnChange -= HandleFlagsChanged;
+    }
+}
+

--- a/BlazorWP/Data/AppFlags.cs
+++ b/BlazorWP/Data/AppFlags.cs
@@ -24,19 +24,26 @@ namespace BlazorWP.Data
         public AuthType Auth { get; private set; } = AuthType.Jwt;
         public Language Language { get; private set; } = Language.English;
 
+        public event Action? OnChange;
+
+        private void NotifyStateChanged() => OnChange?.Invoke();
+
         public void SetAppMode(AppMode mode)
         {
             Mode = mode;
+            NotifyStateChanged();
         }
 
         public void SetAuthMode(AuthType auth)
         {
             Auth = auth;
+            NotifyStateChanged();
         }
 
         public void SetLanguage(Language language)
         {
             Language = language;
+            NotifyStateChanged();
         }
     }
 }

--- a/BlazorWP/Pages/AppFlags.razor
+++ b/BlazorWP/Pages/AppFlags.razor
@@ -89,7 +89,7 @@
     private void SetLanguage(Language lang, string url)
     {
         Flags.SetLanguage(lang);
-        Navigation.NavigateTo(url, forceLoad: true);
+        Navigation.NavigateTo(url);
     }
 }
 


### PR DESCRIPTION
## Summary
- trigger re-render from AppFlags changes by raising an `OnChange` event
- subscribe in `App.razor` to refresh the router when flags update
- navigate without forcing reload when changing language

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b6c4eedd1c83228069cac3483e8044