### PR TITLE
Default media source to WordPress URL

### DIFF
--- a/BlazorWP/Pages/Edit.Lifecycle.cs
+++ b/BlazorWP/Pages/Edit.Lifecycle.cs
@@ -89,6 +89,14 @@ public partial class Edit
             //Console.WriteLine("[OnAfterRenderAsync] firstRender");
             mediaSources = await JwtService.GetSiteInfoKeysAsync();
             selectedMediaSource = await StorageJs.GetItemAsync("mediaSource");
+            if (string.IsNullOrEmpty(selectedMediaSource))
+            {
+                selectedMediaSource = Config["WordPress:Url"];
+                if (!string.IsNullOrEmpty(selectedMediaSource))
+                {
+                    await StorageJs.SetItemAsync("mediaSource", selectedMediaSource);
+                }
+            }
             if (!string.IsNullOrEmpty(selectedMediaSource))
             {
                 await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);

--- a/BlazorWP/Pages/Edit.razor
+++ b/BlazorWP/Pages/Edit.razor
@@ -8,6 +8,7 @@
 @inject LocalStorageJsInterop StorageJs
 @inject WordPressApiService Api
 @inject IStringLocalizer<Edit> L
+@inject IConfiguration Config
 @implements IDisposable
 @implements IAsyncDisposable
 


### PR DESCRIPTION
## Summary
- Inject IConfiguration into edit page
- Default TinyMCE media source to appsettings WordPress URL when no previous selection exists

## Testing
- `dotnet build BlazorWP/BlazorWP.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c94227a8832286f2a02c0f3bdee3