### PR TITLE
Hide media selector and Data Storage link in basic mode

### DIFF
--- a/BlazorWP/Layout/NavMenu.razor
+++ b/BlazorWP/Layout/NavMenu.razor
@@ -39,11 +39,14 @@
                 </NavLink>
             </div>
         }
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="data-storage">
-                <span class="bi bi-database-fill-nav-menu" aria-hidden="true"></span> @L["DataStorage"]
-            </NavLink>
-        </div>
+        @if (Flags.Mode != AppMode.Basic)
+        {
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="data-storage">
+                    <span class="bi bi-database-fill-nav-menu" aria-hidden="true"></span> @L["DataStorage"]
+                </NavLink>
+            </div>
+        }
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="edit">
                 <span class="bi bi-pencil-square" aria-hidden="true"></span> @L["Edit"]

--- a/BlazorWP/Pages/Edit.razor
+++ b/BlazorWP/Pages/Edit.razor
@@ -3,12 +3,14 @@
 @using System.Text.Json
 @using System.Threading
 @using Humanizer
+@using BlazorWP.Data
 @inject IJSRuntime JS
 @inject JwtService JwtService
 @inject LocalStorageJsInterop StorageJs
 @inject WordPressApiService Api
 @inject IStringLocalizer<Edit> L
 @inject IConfiguration Config
+@inject AppFlags Flags
 @implements IDisposable
 @implements IAsyncDisposable
 
@@ -32,7 +34,7 @@
         <label class="form-label" for="postTitle">@L["Title"]</label>
         <input id="postTitle" class="form-control" @bind="postTitle" @bind:event="oninput" @bind:after="OnTitleChanged" />
     </div>
-    @if (mediaSources.Any())
+    @if (mediaSources.Any() && Flags.Mode != AppMode.Basic)
     {
         <div class="mb-3">
             <label class="form-label" for="mediaSource">@L["MediaSource"]</label>


### PR DESCRIPTION
## Summary
- Hide Media Source selector in Edit page when running in basic mode
- Skip Data Storage link in navigation menu for basic mode

## Testing
- `dotnet build BlazorWP/BlazorWP.sln` *(fails: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68b7caf2ed24832288a56509ae606f43