### PR TITLE
Resolve AppFlags ambiguity in Razor components

### DIFF
--- a/BlazorWP/Layout/MainLayout.razor
+++ b/BlazorWP/Layout/MainLayout.razor
@@ -20,5 +20,5 @@
 </div>
 
 @code {
-    [Inject] private AppFlags Flags { get; set; } = default!;
+    [Inject] private BlazorWP.Data.AppFlags Flags { get; set; } = default!;
 }

--- a/BlazorWP/Layout/NavMenu.razor
+++ b/BlazorWP/Layout/NavMenu.razor
@@ -1,6 +1,6 @@
 @using BlazorWP.Data
 @inject IStringLocalizer<NavMenu> L
-@inject AppFlags Flags
+@inject BlazorWP.Data.AppFlags Flags
 @implements IDisposable
 
 <div class="top-row ps-3 navbar navbar-dark">

--- a/BlazorWP/Pages/Edit.razor
+++ b/BlazorWP/Pages/Edit.razor
@@ -10,7 +10,7 @@
 @inject WordPressApiService Api
 @inject IStringLocalizer<Edit> L
 @inject IConfiguration Config
-@inject AppFlags Flags
+@inject BlazorWP.Data.AppFlags Flags
 @implements IDisposable
 @implements IAsyncDisposable
 


### PR DESCRIPTION
## Summary
- Fully qualify AppFlags service injection to ensure the correct data class is used in Razor components

## Testing
- ⚠️ `dotnet build BlazorWP/BlazorWP.csproj` *(dotnet command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ce3c14b08322b726938408f04200