### PR TITLE
Remove mode badge and hide Home in Basic mode

### DIFF
--- a/BlazorWP/Layout/MainLayout.razor
+++ b/BlazorWP/Layout/MainLayout.razor
@@ -1,24 +1,13 @@
 @inherits LayoutComponentBase
 
-@using BlazorWP.Data
 <div class="page">
     <div class="sidebar">
         <NavMenu />
     </div>
 
     <main>
-        <div class="top-row px-4">
-            <span class="badge bg-info ms-3">
-                @(Flags.Mode == AppMode.Basic ? "Basic mode" : "Full mode")
-            </span>
-        </div>
-
         <article class="content px-4">
             @Body
         </article>
     </main>
 </div>
-
-@code {
-    [Inject] private BlazorWP.Data.AppFlags Flags { get; set; } = default!;
-}

--- a/BlazorWP/Layout/NavMenu.razor
+++ b/BlazorWP/Layout/NavMenu.razor
@@ -16,11 +16,14 @@
 
 <div class="@NavMenuCssClass nav-scrollable" @onclick="ToggleNavMenu">
     <nav class="nav flex-column">
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> @L["Home"]
-            </NavLink>
-        </div>
+        @if (Flags.Mode != AppMode.Basic)
+        {
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
+                    <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> @L["Home"]
+                </NavLink>
+            </div>
+        }
         @if (Flags.Mode != AppMode.Basic)
         {
             <div class="nav-item px-3">


### PR DESCRIPTION
## Summary
- Remove Basic/Full mode badge from the main layout header
- Hide Home navigation link when running in Basic mode

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d697a5788322831519672e8ccc48