### PR TITLE
Fix nullability warnings and clean unused field

### DIFF
--- a/BlazorWP/Pages/AppFlags.razor
+++ b/BlazorWP/Pages/AppFlags.razor
@@ -63,7 +63,7 @@
     {
         var uri = Navigation.ToAbsoluteUri(Navigation.Uri);
         var query = QueryHelpers.ParseQuery(uri.Query);
-        var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var dict = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var kvp in query)
         {

--- a/BlazorWP/Pages/Weather.razor
+++ b/BlazorWP/Pages/Weather.razor
@@ -39,7 +39,6 @@ else
 
 @code {
     private WeatherForecast[]? forecasts;
-    private string? jwtToken;
 
     protected override async Task OnInitializedAsync()
     {

--- a/BlazorWP/Pages/WpUsers.razor
+++ b/BlazorWP/Pages/WpUsers.razor
@@ -12,13 +12,13 @@
 {
     <p>@((MarkupString)string.Format(L["NoEndpoint"], $"<NavLink href=\"/\">{L["Home"]}</NavLink>"))</p>
 }
-else if (users == null && string.IsNullOrEmpty(error))
-{
-    <p><em>@L["Loading"]</em></p>
-}
 else if (!string.IsNullOrEmpty(error))
 {
     <p class="text-danger">@L["Error", error]</p>
+}
+else if (users == null)
+{
+    <p><em>@L["Loading"]</em></p>
 }
 else
 {

--- a/BlazorWP/Program.cs
+++ b/BlazorWP/Program.cs
@@ -165,7 +165,7 @@ namespace BlazorWP
                     {
                         foreach (var v in kvp.Value)
                         {
-                            segments.Add($"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(v)}");
+                            segments.Add($"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(v ?? string.Empty)}");
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- handle possible nulls in `WpUsers` flow
- use nullable dictionary values when building query strings
- guard `Uri.EscapeDataString` against null values
- remove unused field from weather page

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d3d44318832298b821cd5b5f79a4