### PR TITLE
Abstract WordPress API service for better testability

### DIFF
--- a/BlazorWP/Data/IWordPressApiService.cs
+++ b/BlazorWP/Data/IWordPressApiService.cs
@@ -1,0 +1,13 @@
+using WordPressPCL;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace BlazorWP;
+
+public interface IWordPressApiService
+{
+    void SetEndpoint(string endpoint);
+    Task<WordPressClient?> GetClientAsync();
+    WordPressClient? Client { get; }
+    HttpClient? HttpClient { get; }
+}

--- a/BlazorWP/Data/WordPressApiService.cs
+++ b/BlazorWP/Data/WordPressApiService.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace BlazorWP;
 
-public sealed class WordPressApiService
+public sealed class WordPressApiService : IWordPressApiService
 {
     private readonly AuthMessageHandler _auth;
     private readonly LocalStorageJsInterop _storage;

--- a/BlazorWP/Pages/ApprovedEmailDemo.razor
+++ b/BlazorWP/Pages/ApprovedEmailDemo.razor
@@ -2,7 +2,7 @@
 @using WordPressPCL
 @using System.Net.Http.Json
 @using System.Text.Json
-@inject WordPressApiService Api
+@inject IWordPressApiService Api
 
 <PageTitle>Approved Email Demo</PageTitle>
 

--- a/BlazorWP/Pages/Edit.razor
+++ b/BlazorWP/Pages/Edit.razor
@@ -7,7 +7,7 @@
 @inject IJSRuntime JS
 @inject JwtService JwtService
 @inject LocalStorageJsInterop StorageJs
-@inject WordPressApiService Api
+@inject IWordPressApiService Api
 @inject IStringLocalizer<Edit> L
 @inject IConfiguration Config
 @inject BlazorWP.Data.AppFlags Flags

--- a/BlazorWP/Pages/PclDemo.razor
+++ b/BlazorWP/Pages/PclDemo.razor
@@ -2,7 +2,7 @@
 @using WordPressPCL
 @inject IJSRuntime JS
 @inject JwtService JwtService
-@inject WordPressApiService Api
+@inject IWordPressApiService Api
 
 <PageTitle>PCL Demo</PageTitle>
 

--- a/BlazorWP/Pages/UploadPdf.razor
+++ b/BlazorWP/Pages/UploadPdf.razor
@@ -7,7 +7,7 @@
 @using System.IO
 @using System.Net.Http
 @inject UploadPdfJsInterop PdfJs
-@inject WordPressApiService Api
+@inject IWordPressApiService Api
 
 <PageTitle>Upload PDF</PageTitle>
 

--- a/BlazorWP/Pages/WpUsers.razor
+++ b/BlazorWP/Pages/WpUsers.razor
@@ -3,7 +3,7 @@
 @using WordPressPCL.Models
 @using Microsoft.AspNetCore.Components
 @inject JwtService JwtService
-@inject WordPressApiService Api
+@inject IWordPressApiService Api
 @inject IStringLocalizer<WpUsers> L
 
 <PageTitle>@L["WordPressUsersTitle"]</PageTitle>

--- a/BlazorWP/Program.cs
+++ b/BlazorWP/Program.cs
@@ -40,7 +40,7 @@ namespace BlazorWP
             builder.Services.AddScoped<CredentialManagerJsInterop>();
             builder.Services.AddScoped<ClipboardJsInterop>();
             builder.Services.AddScoped<WpMediaJsInterop>();
-            builder.Services.AddScoped<WordPressApiService>();
+            builder.Services.AddScoped<IWordPressApiService, WordPressApiService>();
             builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
             builder.Services.AddSingleton<LanguageService>();
             builder.Services.AddSingleton<AppFlags>();


### PR DESCRIPTION
## Summary
- Add `IWordPressApiService` interface and implement it in `WordPressApiService`
- Register and inject the API service via the new interface across the app

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b9379f56cc8322b0257072190f5074