### PR TITLE
Add local store abstraction and in-memory test implementation

### DIFF
--- a/BlazorWP.Tests/BlazorWP.Tests.csproj
+++ b/BlazorWP.Tests/BlazorWP.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../BlazorWP/BlazorWP.csproj" />
+  </ItemGroup>
+</Project>

--- a/BlazorWP.Tests/InMemoryLocalStore.cs
+++ b/BlazorWP.Tests/InMemoryLocalStore.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using BlazorWP.Data;
+
+namespace BlazorWP.Tests;
+
+public sealed class InMemoryLocalStore : ILocalStore
+{
+    private readonly Dictionary<string, List<object>> _stores = new(StringComparer.Ordinal);
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task<T?> GetByKeyAsync<T>(string storeName, object key)
+    {
+        var list = _stores.GetValueOrDefault(storeName) ?? [];
+        var match = list.Cast<T>().FirstOrDefault();
+        return Task.FromResult(match);
+    }
+
+    public Task<IReadOnlyList<T>> GetAllAsync<T>(string storeName)
+    {
+        var list = _stores.GetValueOrDefault(storeName)?.Cast<T>().ToList() ?? new List<T>();
+        return Task.FromResult<IReadOnlyList<T>>(list);
+    }
+
+    public Task AddAsync<T>(string storeName, T item)
+    {
+        if (!_stores.TryGetValue(storeName, out var list))
+        {
+            list = new List<object>();
+            _stores[storeName] = list;
+        }
+        list.Add(item!);
+        return Task.CompletedTask;
+    }
+
+    public Task PutAsync<T>(string storeName, T item) => AddAsync(storeName, item);
+
+    public Task DeleteAsync(string storeName, object key) => Task.CompletedTask;
+}

--- a/BlazorWP.Tests/LocalStoreTests.cs
+++ b/BlazorWP.Tests/LocalStoreTests.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Xunit;
+using BlazorWP.Data;
+
+namespace BlazorWP.Tests;
+
+public class LocalStoreTests
+{
+    [Fact]
+    public async Task Add_Todo_Saves_To_LocalStore()
+    {
+        ILocalStore store = new InMemoryLocalStore();
+        await store.AddAsync("todos", new Todo { Title = "Write tests" });
+
+        var all = await store.GetAllAsync<Todo>("todos");
+        Assert.Contains(all, t => t.Title == "Write tests");
+    }
+
+    private class Todo
+    {
+        public string? Title { get; set; }
+    }
+}

--- a/BlazorWP/BlazorWP.sln
+++ b/BlazorWP/BlazorWP.sln
@@ -4,20 +4,26 @@ VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorWP", "BlazorWP.csproj", "{DB1C0860-F07D-47F6-0828-CF0581B62AC3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorWP.Tests", "BlazorWP.Tests\\BlazorWP.Tests.csproj", "{E4FB8B32-E900-4689-AF97-519F9EBB1CF1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{DB1C0860-F07D-47F6-0828-CF0581B62AC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DB1C0860-F07D-47F6-0828-CF0581B62AC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DB1C0860-F07D-47F6-0828-CF0581B62AC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DB1C0860-F07D-47F6-0828-CF0581B62AC3}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {DB1C0860-F07D-47F6-0828-CF0581B62AC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {DB1C0860-F07D-47F6-0828-CF0581B62AC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {DB1C0860-F07D-47F6-0828-CF0581B62AC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {DB1C0860-F07D-47F6-0828-CF0581B62AC3}.Release|Any CPU.Build.0 = Release|Any CPU
+                {E4FB8B32-E900-4689-AF97-519F9EBB1CF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E4FB8B32-E900-4689-AF97-519F9EBB1CF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E4FB8B32-E900-4689-AF97-519F9EBB1CF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E4FB8B32-E900-4689-AF97-519F9EBB1CF1}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
+        EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8722291D-F465-4CF1-9A3B-62EF098FEF07}
 	EndGlobalSection

--- a/BlazorWP/Data/ILocalStore.cs
+++ b/BlazorWP/Data/ILocalStore.cs
@@ -1,0 +1,11 @@
+namespace BlazorWP.Data;
+
+public interface ILocalStore
+{
+    Task InitializeAsync();
+    Task<T?> GetByKeyAsync<T>(string storeName, object key);
+    Task<IReadOnlyList<T>> GetAllAsync<T>(string storeName);
+    Task AddAsync<T>(string storeName, T item);
+    Task PutAsync<T>(string storeName, T item);
+    Task DeleteAsync(string storeName, object key);
+}

--- a/BlazorWP/Data/IndexedDbLocalStore.cs
+++ b/BlazorWP/Data/IndexedDbLocalStore.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using TG.Blazor.IndexedDB;
+
+namespace BlazorWP.Data;
+
+public sealed class IndexedDbLocalStore : ILocalStore
+{
+    private readonly IndexedDBManager _db;
+
+    public IndexedDbLocalStore(IndexedDBManager db) => _db = db;
+
+    public Task InitializeAsync() => _db.OpenDb();
+
+    public async Task<T?> GetByKeyAsync<T>(string storeName, object key)
+        => await _db.GetRecordById<T>(storeName, key);
+
+    public async Task<IReadOnlyList<T>> GetAllAsync<T>(string storeName)
+        => (await _db.GetRecords<T>(storeName)).AsReadOnly();
+
+    public Task AddAsync<T>(string storeName, T item)
+        => _db.AddRecord(new StoreRecord<T> { Storename = storeName, Data = item });
+
+    public Task PutAsync<T>(string storeName, T item)
+        => _db.UpdateRecord(new StoreRecord<T> { Storename = storeName, Data = item });
+
+    public Task DeleteAsync(string storeName, object key)
+        => _db.DeleteRecord(storeName, key);
+}

--- a/BlazorWP/Pages/IndexedDbDemo.razor
+++ b/BlazorWP/Pages/IndexedDbDemo.razor
@@ -1,6 +1,5 @@
 @page "/indexeddb-demo"
-@using TG.Blazor.IndexedDB
-@inject IndexedDBManager DbManager
+@inject ILocalStore LocalStore
 
 <PageTitle>IndexedDB Demo</PageTitle>
 
@@ -70,7 +69,7 @@ else
     // Fetch all notes from the "notes" object store
     private async Task LoadNotesAsync()
     {
-        notes = await DbManager.GetRecords<Note>("notes") ?? new List<Note>();
+        notes = (await LocalStore.GetAllAsync<Note>("notes")).ToList();
         StateHasChanged();
     }
 
@@ -80,19 +79,11 @@ else
         if (!isEditing)
         {
             currentNote.Id = Guid.NewGuid().ToString();
-            await DbManager.AddRecord(new StoreRecord<Note>
-            {
-                Storename = "notes",
-                Data = currentNote
-            });
+            await LocalStore.AddAsync("notes", currentNote);
         }
         else
         {
-            await DbManager.UpdateRecord(new StoreRecord<Note>
-            {
-                Storename = "notes",
-                Data = currentNote
-            });
+            await LocalStore.PutAsync("notes", currentNote);
         }
 
         await LoadNotesAsync();   // Refresh the notes list from the database
@@ -116,7 +107,7 @@ else
     // Delete a note from the database
     private async Task DeleteNote(Note note)
     {
-        await DbManager.DeleteRecord<string>("notes", note.Id);
+        await LocalStore.DeleteAsync("notes", note.Id);
         await LoadNotesAsync(); // Refresh the list to reflect deletion
     }
 

--- a/BlazorWP/Program.cs
+++ b/BlazorWP/Program.cs
@@ -61,6 +61,7 @@ namespace BlazorWP
                     // Add Indexes = new List<IndexSpec> { ... } if you want secondary indexes
                 });
             });
+            builder.Services.AddScoped<ILocalStore, IndexedDbLocalStore>();
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();

--- a/BlazorWP/_Imports.razor
+++ b/BlazorWP/_Imports.razor
@@ -16,3 +16,4 @@
 @using PanoramicData.Blazor.Arguments
 @using Microsoft.Extensions.Configuration
 @using Microsoft.Extensions.Localization
+@using BlazorWP.Data


### PR DESCRIPTION
## Summary
- Extract ILocalStore interface to decouple components from TG.Blazor.IndexedDB
- Wrap IndexedDBManager with IndexedDbLocalStore and register it for DI
- Provide test project with InMemoryLocalStore and a sample xUnit test

## Testing
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `dotnet test BlazorWP/BlazorWP.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b93d4405708322889af4e0057ae4d7