### PR TITLE
Specify key type for IndexedDB lookups

### DIFF
--- a/BlazorWP/Data/IndexedDbLocalStore.cs
+++ b/BlazorWP/Data/IndexedDbLocalStore.cs
@@ -12,7 +12,7 @@ public sealed class IndexedDbLocalStore : ILocalStore
     public Task InitializeAsync() => _db.OpenDb();
 
     public async Task<T?> GetByKeyAsync<T>(string storeName, object key)
-        => await _db.GetRecordById<T>(storeName, key);
+        => await _db.GetRecordById<object, T>(storeName, key);
 
     public async Task<IReadOnlyList<T>> GetAllAsync<T>(string storeName)
         => (await _db.GetRecords<T>(storeName)).AsReadOnly();


### PR DESCRIPTION
## Summary
- fix IndexedDB get-by-id lookup to supply key type

## Testing
- `dotnet build BlazorWP` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b93f898ee08322a89e8465473ffe83