### PR TITLE
Allow word wrapping on PCL demo

### DIFF
--- a/BlazorWP/wwwroot/css/app.css
+++ b/BlazorWP/wwwroot/css/app.css
@@ -144,3 +144,14 @@ code {
 .article-row {
     cursor: pointer;
 }
+
+#pclAccordion code {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+#pclAccordion .json-view {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}


### PR DESCRIPTION
## Summary
- prevent long tokens from widening the PCL demo by allowing word wrapping on code and JSON sections

## Testing
- `dotnet test BlazorWP/BlazorWP.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b94a5bde148322821ef9322ed91ff2