### PR TITLE
Replace FluentAssertions with xUnit asserts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,6 @@
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
     <PackageVersion Include="xunit.analyzers" Version="1.24.0" />
-    <PackageVersion Include="FluentAssertions" Version="8.6.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <!-- Shared libs -->
     <PackageVersion Include="Microsoft.Extensions.Localization" Version="9.0.8" />

--- a/WpDI/tests/Editor.Tests/AdminAuthTests.cs
+++ b/WpDI/tests/Editor.Tests/AdminAuthTests.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
-using FluentAssertions;
 using Xunit;
 
 [Collection("WP EndToEnd")]
@@ -49,7 +48,7 @@ public class AdminAuthTests
 
         using var http = NewClient(baseUrl!);
         var resp = await http.GetAsync("/wp-json/wp/v2/settings/");
-        resp.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+        Assert.Contains(resp.StatusCode, new[] { HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden });
 
     }
 
@@ -63,7 +62,7 @@ public class AdminAuthTests
         SetBasicAuth(http, "admin", "DefinitelyWrongPassword123!");
 
         var resp = await http.GetAsync("/wp-json/wp/v2/settings");
-        resp.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+        Assert.Contains(resp.StatusCode, new[] { HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden });
     }
 
     [Fact]
@@ -78,9 +77,9 @@ public class AdminAuthTests
         SetBasicAuth(http, user, pass);
 
         var resp = await http.GetAsync("/wp-json/wp/v2/settings/");
-        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         var json = await resp.Content.ReadAsStringAsync();
-        json.Should().Contain("\"title\"");
+        Assert.Contains("\"title\"", json);
     }
 
     [Fact]
@@ -92,11 +91,11 @@ public class AdminAuthTests
         SetBasicAuth(http, user, pass);
 
         var resp = await http.GetAsync("/wp-json/wp/v2/users/me/");
-        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
 
         var body = await resp.Content.ReadAsStringAsync();
-        body.Should().Contain("\"id\"");
-        body.Should().Contain("\"name\"");
+        Assert.Contains("\"id\"", body);
+        Assert.Contains("\"name\"", body);
     }
 }
 

--- a/WpDI/tests/Editor.Tests/Editor.Tests.csproj
+++ b/WpDI/tests/Editor.Tests/Editor.Tests.csproj
@@ -14,7 +14,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Reflection.Metadata" />

--- a/WpDI/tests/Editor.Tests/WpCliCleanup.cs
+++ b/WpDI/tests/Editor.Tests/WpCliCleanup.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using FluentAssertions;
 using Xunit;
 
 [CollectionDefinition("WP EndToEnd", DisableParallelization = true)]
@@ -48,12 +47,12 @@ public sealed class WpCliCleanupFixture : IAsyncLifetime
         if (int.TryParse(fromEnv, out var envId) && envId > 0) return envId;
 
         var (code, output, err) = await RunWpAsync(wp, wpPath, "user list --role=administrator --field=ID --format=ids");
-        code.Should().Be(0, $"wp user list (admins) should succeed. stderr: {err}");
+        Assert.True(code == 0, $"wp user list (admins) should succeed. stderr: {err}");
 
         var first = output.Split(new[] { ' ', '\n', '\r', '\t', ',' }, StringSplitOptions.RemoveEmptyEntries)
                           .FirstOrDefault();
-        int.TryParse(first, out var adminId).Should().BeTrue("must have at least one admin user");
-        adminId.Should().BeGreaterThan(0);
+        Assert.True(int.TryParse(first, out var adminId), "must have at least one admin user");
+        Assert.True(adminId > 0);
         return adminId;
     }
 
@@ -64,7 +63,7 @@ public sealed class WpCliCleanupFixture : IAsyncLifetime
             "post list --post_type=any --post_status=any --field=ID --format=ids",
             timeoutMs: 30000);
 
-        codeList.Should().Be(0, $"wp post list should succeed. stderr: {errList}");
+        Assert.True(codeList == 0, $"wp post list should succeed. stderr: {errList}");
 
         ids = (ids ?? "").Trim();
         if (string.IsNullOrEmpty(ids))
@@ -85,7 +84,7 @@ public sealed class WpCliCleanupFixture : IAsyncLifetime
                 $"post delete {batch} --force",
                 timeoutMs: 60000);
 
-            codeDel.Should().Be(0, $"wp post delete should succeed. stderr: {errDel}");
+            Assert.True(codeDel == 0, $"wp post delete should succeed. stderr: {errDel}");
         }
     }
 
@@ -95,7 +94,7 @@ public sealed class WpCliCleanupFixture : IAsyncLifetime
             wp, wpPath,
             "user list --field=ID --role__not_in=administrator --format=ids");
 
-        codeList.Should().Be(0, $"wp user list (non-admins) should succeed. stderr: {errList}");
+        Assert.True(codeList == 0, $"wp user list (non-admins) should succeed. stderr: {errList}");
 
         ids = (ids ?? "").Trim();
         if (string.IsNullOrEmpty(ids))
@@ -110,7 +109,7 @@ public sealed class WpCliCleanupFixture : IAsyncLifetime
             $"user delete {ids} --yes",
             timeoutMs: 60000);
 
-        codeDel.Should().Be(0, $"wp user delete should succeed. stderr: {errDel}");
+        Assert.True(codeDel == 0, $"wp user delete should succeed. stderr: {errDel}");
     }
 
     public async Task InitializeAsync()
@@ -124,7 +123,7 @@ public sealed class WpCliCleanupFixture : IAsyncLifetime
         }
 
         var (verCode, verOut, verErr) = await RunWpAsync(wp, wpPath, "--version");
-        verCode.Should().Be(0, $"wp --version must work. stderr: {verErr}");
+        Assert.True(verCode == 0, $"wp --version must work. stderr: {verErr}");
         Console.WriteLine($"Using WP-CLI: {verOut.Trim()}");
 
         // 1) Delete all posts first

--- a/WpDI/tests/Editor.Tests/WpCliSanityTests.cs
+++ b/WpDI/tests/Editor.Tests/WpCliSanityTests.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 using System.Text.RegularExpressions;
-using FluentAssertions;
+using Xunit;
 
 public class WpCliSanityTests
 {
@@ -40,13 +40,13 @@ public class WpCliSanityTests
 
         // 1) Check version first — does not require a WP install and is fast
         var (codeVer, outVer, errVer) = Run(wp, "--version");
-        codeVer.Should().Be(0, $"wp --version should succeed but stderr was: {errVer}");
-        outVer.Should().MatchRegex(new Regex(@"WP-CLI\s+\d+\.\d+(\.\d+)?", RegexOptions.IgnoreCase));
+        Assert.True(codeVer == 0, $"wp --version should succeed but stderr was: {errVer}");
+        Assert.Matches(new Regex(@"WP-CLI\s+\d+\.\d+(\.\d+)?", RegexOptions.IgnoreCase), outVer);
 
         // 2) Optional: info command — also lightweight
         var (codeInfo, outInfo, errInfo) = Run(wp, "--info");
-        codeInfo.Should().Be(0, $"wp --info should succeed but stderr was: {errInfo}");
-        outInfo.Should().ContainAny("WP-CLI root dir", "PHP binary", "OS:", "Shell:");
+        Assert.True(codeInfo == 0, $"wp --info should succeed but stderr was: {errInfo}");
+        Assert.True(outInfo.Contains("WP-CLI root dir") || outInfo.Contains("PHP binary") || outInfo.Contains("OS:") || outInfo.Contains("Shell:"));
         
         // For visibility in test logs
         Console.WriteLine($"WP_CLI used: {wp}");


### PR DESCRIPTION
## Summary
- switch tests to xUnit assertions
- drop FluentAssertions dependency

## Testing
- `dotnet test WpDI/tests/Editor.Tests/Editor.Tests.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3eeaa60b48322a055f9245afdb066