### PR TITLE
Move WordPress API abstraction to WPDI

### DIFF
--- a/BlazorWP/Data/WordPressApiService.cs
+++ b/BlazorWP/Data/WordPressApiService.cs
@@ -2,6 +2,7 @@ using WordPressPCL;
 using System.Net.Http;
 using System;
 using System.Threading.Tasks;
+using Editor.WordPress;
 
 namespace BlazorWP;
 

--- a/BlazorWP/Program.cs
+++ b/BlazorWP/Program.cs
@@ -1,4 +1,5 @@
 using BlazorWP.Data;
+using Editor.WordPress;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;

--- a/BlazorWP/_Imports.razor
+++ b/BlazorWP/_Imports.razor
@@ -15,3 +15,4 @@
 @using Microsoft.Extensions.Configuration
 @using Microsoft.Extensions.Localization
 @using BlazorWP.Data
+@using Editor.WordPress

--- a/WpDI/src/Editor.WordPress/Editor.WordPress.csproj
+++ b/WpDI/src/Editor.WordPress/Editor.WordPress.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="System.Resources.Extensions" />
+    <PackageReference Include="WordPressPCL" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/WpDI/src/Editor.WordPress/IWordPressApiService.cs
+++ b/WpDI/src/Editor.WordPress/IWordPressApiService.cs
@@ -2,7 +2,7 @@ using WordPressPCL;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-namespace BlazorWP;
+namespace Editor.WordPress;
 
 public interface IWordPressApiService
 {

--- a/WpDI/src/Editor.WordPress/WordPressApiDI.cs
+++ b/WpDI/src/Editor.WordPress/WordPressApiDI.cs
@@ -1,0 +1,17 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Editor.WordPress;
+
+public static class WordPressApiDI
+{
+    public static IServiceCollection AddWordPressApiAppPassword(this IServiceCollection services, Action<WordPressOptions> configure)
+    {
+        if (services == null) throw new ArgumentNullException(nameof(services));
+        if (configure == null) throw new ArgumentNullException(nameof(configure));
+
+        services.Configure(configure);
+        services.AddSingleton<IWordPressApiService, WordPressApiService>();
+        return services;
+    }
+}

--- a/WpDI/src/Editor.WordPress/WordPressApiService.cs
+++ b/WpDI/src/Editor.WordPress/WordPressApiService.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using WordPressPCL;
+
+namespace Editor.WordPress;
+
+public sealed class WordPressApiService : IWordPressApiService
+{
+    private readonly HttpClient _http;
+    private WordPressClient? _client;
+
+    public WordPressApiService(IOptions<WordPressOptions> options)
+    {
+        if (options == null) throw new ArgumentNullException(nameof(options));
+        var opt = options.Value;
+        var handler = new AppPasswordHandler(opt.UserName, opt.AppPassword)
+        {
+            InnerHandler = new HttpClientHandler()
+        };
+        _http = new HttpClient(handler)
+        {
+            Timeout = opt.Timeout
+        };
+        SetEndpoint(opt.BaseUrl);
+    }
+
+    public void SetEndpoint(string endpoint)
+    {
+        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
+        _http.BaseAddress = new Uri(baseUrl);
+        _http.DefaultRequestHeaders.Accept.ParseAdd("application/json");
+        _client = new WordPressClient(_http);
+    }
+
+    public Task<WordPressClient?> GetClientAsync() => Task.FromResult(_client);
+
+    public WordPressClient? Client => _client;
+    public HttpClient? HttpClient => _http;
+
+    private sealed class AppPasswordHandler : DelegatingHandler
+    {
+        private readonly string _user;
+        private readonly string _pass;
+
+        public AppPasswordHandler(string user, string pass)
+        {
+            _user = user;
+            _pass = pass;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            BasicAuth.Apply(request, _user, _pass);
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Define IWordPressApiService inside WPDI and expose it to consumers
- Add app-password WordPressApiService with Basic Auth and DI helper
- Update BlazorWP to use WPDI's service interface and remove local copy

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c42098ab48832288e83af06ba24085