### PR TITLE
Reload when switching auth mode

### DIFF
--- a/BlazorWP/Pages/AppFlags.razor
+++ b/BlazorWP/Pages/AppFlags.razor
@@ -92,7 +92,7 @@
     private async Task SetAuth(AuthType type, string url)
     {
         await Flags.SetAuthMode(type);
-        Navigation.NavigateTo(url);
+        Navigation.NavigateTo(url, forceLoad: true);
     }
 
     private async Task SetLanguage(Language lang, string url)


### PR DESCRIPTION
## Summary
- Reload the app when toggling between nonce and app password modes so authentication mode is set at startup like language

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ea966efc83229f6760ee0354f4bc