### PR TITLE
Add localization to demo pages

### DIFF
--- a/src/BlazorWP/Pages/BootstrapIconsDemo.razor
+++ b/src/BlazorWP/Pages/BootstrapIconsDemo.razor
@@ -1,26 +1,28 @@
 @page "/bootstrap-icons-demo"
+@using Microsoft.AspNetCore.Components
+@inject IStringLocalizer<BootstrapIconsDemo> L
 
-<PageTitle>Bootstrap Icons Demo</PageTitle>
+<PageTitle>@L["Title"]</PageTitle>
 
-<h3>Bootstrap Icons Demo</h3>
+<h3>@L["Heading"]</h3>
 
-<p>The Bootstrap Icons library was added via LibMan. Below are a few sample icons using the <code>bi</code> classes.</p>
+<p>@((MarkupString)L["Description"])</p>
 
 <div class="d-flex gap-3 flex-wrap">
     <div class="text-center">
         <i class="bi bi-alarm" style="font-size: 2rem;" aria-hidden="true"></i>
-        <div>alarm</div>
+        <div>@L["AlarmLabel"]</div>
     </div>
     <div class="text-center">
         <i class="bi bi-basket" style="font-size: 2rem;" aria-hidden="true"></i>
-        <div>basket</div>
+        <div>@L["BasketLabel"]</div>
     </div>
     <div class="text-center">
         <i class="bi bi-bezier" style="font-size: 2rem;" aria-hidden="true"></i>
-        <div>bezier</div>
+        <div>@L["BezierLabel"]</div>
     </div>
     <div class="text-center">
         <i class="bi bi-brush" style="font-size: 2rem;" aria-hidden="true"></i>
-        <div>brush</div>
+        <div>@L["BrushLabel"]</div>
     </div>
 </div>

--- a/src/BlazorWP/Pages/Counter.razor
+++ b/src/BlazorWP/Pages/Counter.razor
@@ -1,12 +1,13 @@
-﻿@page "/counter"
+@page "/counter"
+@inject IStringLocalizer<Counter> L
 
-<PageTitle>Counter</PageTitle>
+<PageTitle>@L["Title"]</PageTitle>
 
-<h1>Counter</h1>
+<h1>@L["Heading"]</h1>
 
-<p role="status">Current count: @currentCount</p>
+<p role="status">@L["CurrentCount", currentCount]</p>
 
-<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+<button class="btn btn-primary" @onclick="IncrementCount">@L["IncrementButton"]</button>
 
 @code {
     private int currentCount = 0;

--- a/src/BlazorWP/Pages/Weather.razor
+++ b/src/BlazorWP/Pages/Weather.razor
@@ -1,26 +1,26 @@
-﻿@page "/weather"
+@page "/weather"
 @inject HttpClient Http
+@inject IStringLocalizer<Weather> L
 
-<PageTitle>Weather</PageTitle>
+<PageTitle>@L["Title"]</PageTitle>
 
-<h1>Weather</h1>
+<h1>@L["Heading"]</h1>
 
-<p>This component demonstrates fetching data from the server.</p>
-
+<p>@L["Description"]</p>
 
 @if (forecasts == null)
 {
-    <p><em>Loading...</em></p>
+    <p><em>@L["Loading"]</em></p>
 }
 else
 {
     <table class="table">
         <thead>
             <tr>
-                <th>Date</th>
-                <th aria-label="Temperature in Celsius">Temp. (C)</th>
-                <th aria-label="Temperature in Farenheit">Temp. (F)</th>
-                <th>Summary</th>
+                <th>@L["ColumnDate"]</th>
+                <th aria-label='@L["ColumnCelsiusAria"]'>@L["ColumnCelsius"]</th>
+                <th aria-label='@L["ColumnFahrenheitAria"]'>@L["ColumnFahrenheit"]</th>
+                <th>@L["ColumnSummary"]</th>
             </tr>
         </thead>
         <tbody>

--- a/src/BlazorWP/Resources/Pages/BootstrapIconsDemo.ja.resx
+++ b/src/BlazorWP/Resources/Pages/BootstrapIconsDemo.ja.resx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>Bootstrap アイコン デモ</value></data>
+  <data name="Heading" xml:space="preserve"><value>Bootstrap アイコン デモ</value></data>
+  <data name="Description" xml:space="preserve"><value>Bootstrap Icons ライブラリは LibMan 経由で追加されました。以下は &lt;code&gt;bi&lt;/code&gt; クラスを使用したサンプルアイコンです。</value></data>
+  <data name="AlarmLabel" xml:space="preserve"><value>アラーム</value></data>
+  <data name="BasketLabel" xml:space="preserve"><value>バスケット</value></data>
+  <data name="BezierLabel" xml:space="preserve"><value>ベジエ</value></data>
+  <data name="BrushLabel" xml:space="preserve"><value>ブラシ</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/BootstrapIconsDemo.resx
+++ b/src/BlazorWP/Resources/Pages/BootstrapIconsDemo.resx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>Bootstrap Icons Demo</value></data>
+  <data name="Heading" xml:space="preserve"><value>Bootstrap Icons Demo</value></data>
+  <data name="Description" xml:space="preserve"><value>The Bootstrap Icons library was added via LibMan. Below are a few sample icons using the &lt;code&gt;bi&lt;/code&gt; classes.</value></data>
+  <data name="AlarmLabel" xml:space="preserve"><value>alarm</value></data>
+  <data name="BasketLabel" xml:space="preserve"><value>basket</value></data>
+  <data name="BezierLabel" xml:space="preserve"><value>bezier</value></data>
+  <data name="BrushLabel" xml:space="preserve"><value>brush</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/Counter.ja.resx
+++ b/src/BlazorWP/Resources/Pages/Counter.ja.resx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>カウンター</value></data>
+  <data name="Heading" xml:space="preserve"><value>カウンター</value></data>
+  <data name="CurrentCount" xml:space="preserve"><value>現在のカウント: {0}</value></data>
+  <data name="IncrementButton" xml:space="preserve"><value>クリックして増やす</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/Counter.resx
+++ b/src/BlazorWP/Resources/Pages/Counter.resx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>Counter</value></data>
+  <data name="Heading" xml:space="preserve"><value>Counter</value></data>
+  <data name="CurrentCount" xml:space="preserve"><value>Current count: {0}</value></data>
+  <data name="IncrementButton" xml:space="preserve"><value>Click me</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/Weather.ja.resx
+++ b/src/BlazorWP/Resources/Pages/Weather.ja.resx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>天気</value></data>
+  <data name="Heading" xml:space="preserve"><value>天気</value></data>
+  <data name="Description" xml:space="preserve"><value>このコンポーネントはサーバーからデータを取得する方法を示しています。</value></data>
+  <data name="Loading" xml:space="preserve"><value>読み込み中...</value></data>
+  <data name="ColumnDate" xml:space="preserve"><value>日付</value></data>
+  <data name="ColumnCelsius" xml:space="preserve"><value>気温 (℃)</value></data>
+  <data name="ColumnFahrenheit" xml:space="preserve"><value>気温 (℉)</value></data>
+  <data name="ColumnSummary" xml:space="preserve"><value>概要</value></data>
+  <data name="ColumnCelsiusAria" xml:space="preserve"><value>摂氏の気温</value></data>
+  <data name="ColumnFahrenheitAria" xml:space="preserve"><value>華氏の気温</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/Weather.resx
+++ b/src/BlazorWP/Resources/Pages/Weather.resx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>Weather</value></data>
+  <data name="Heading" xml:space="preserve"><value>Weather</value></data>
+  <data name="Description" xml:space="preserve"><value>This component demonstrates fetching data from the server.</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading...</value></data>
+  <data name="ColumnDate" xml:space="preserve"><value>Date</value></data>
+  <data name="ColumnCelsius" xml:space="preserve"><value>Temp. (C)</value></data>
+  <data name="ColumnFahrenheit" xml:space="preserve"><value>Temp. (F)</value></data>
+  <data name="ColumnSummary" xml:space="preserve"><value>Summary</value></data>
+  <data name="ColumnCelsiusAria" xml:space="preserve"><value>Temperature in Celsius</value></data>
+  <data name="ColumnFahrenheitAria" xml:space="preserve"><value>Temperature in Fahrenheit</value></data>
+</root>


### PR DESCRIPTION
## Summary
- update the Counter, Weather, and Bootstrap Icons demo components to read all UI text from localized resources
- add English and Japanese resource files for each page so the demos match the bilingual WP Users page

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d769b0158c8322915e65d38fd73804