### PR TITLE
Localize remaining Razor pages

### DIFF
--- a/src/BlazorWP/Pages/AppFlags.razor
+++ b/src/BlazorWP/Pages/AppFlags.razor
@@ -8,30 +8,31 @@
 @inject IWordPressApiService Api
 @inject AppPasswordService AppPassService
 @inject WpNonceJsInterop NonceJs
+@inject IStringLocalizer<AppFlags> L
 @implements IDisposable
 
-<PageTitle>App Flags</PageTitle>
+<PageTitle>@L["Title"]</PageTitle>
 
 <section aria-labelledby="appflags-heading" class="container py-3" data-testid="appflags-page">
-    <h3 id="appflags-heading" class="mb-3">Application Flags</h3>
+    <h3 id="appflags-heading" class="mb-3">@L["Heading"]</h3>
 
     <div class="alert alert-light border" role="status" aria-live="polite" data-testid="state-panel">
-        <div>Mode: <span data-testid="state-mode">@Flags.Mode</span></div>
-        <div>Auth: <span data-testid="state-auth">@Flags.Auth</span></div>
-        <div>Language: <span data-testid="state-lang">@Flags.Language</span></div>
-        <div>WP URL: <span data-testid="state-wpurl">@Flags.WpUrl</span></div>
+        <div>@L["StateModeLabel"] <span data-testid="state-mode">@GetModeLabel(Flags.Mode)</span></div>
+        <div>@L["StateAuthLabel"] <span data-testid="state-auth">@GetAuthLabel(Flags.Auth)</span></div>
+        <div>@L["StateLanguageLabel"] <span data-testid="state-lang">@GetLanguageLabel(Flags.Language)</span></div>
+        <div>@L["StateWpUrlLabel"] <span data-testid="state-wpurl">@Flags.WpUrl</span></div>
     </div>
 
     <table class="table table-striped" data-testid="flags-table">
         <thead>
             <tr>
-                <th scope="col">Feature</th>
-                <th scope="col">Options</th>
+                <th scope="col">@L["FeatureHeader"]</th>
+                <th scope="col">@L["OptionsHeader"]</th>
             </tr>
         </thead>
         <tbody>
             <tr data-testid="row-appmode">
-                <td><label id="appmode-label">App Mode</label></td>
+                <td><label id="appmode-label">@L["AppModeLabel"]</label></td>
                 <td aria-labelledby="appmode-label">
                     @foreach (AppMode mode in Enum.GetValues<AppMode>())
                     {
@@ -39,14 +40,14 @@
                         var url = BuildUrl("appmode", mode == AppMode.Basic ? "basic" : "full");
                         <button type="button" class="btn btn-sm me-1 @(active ? "btn-primary" : "btn-outline-secondary")"
                             role="button" aria-pressed="@active" data-testid="@($"appmode-{mode.ToString().ToLower()}")"
-                            title="@($"Set App Mode to {mode}")" @onclick="() => SetAppMode(mode, url)">
-                            @mode
+                            title="@L["SetAppModeTo", GetModeLabel(mode)]" @onclick="() => SetAppMode(mode, url)">
+                            @GetModeLabel(mode)
                         </button>
                     }
                 </td>
             </tr>
             <tr data-testid="row-authtype">
-                <td><label id="authtype-label">Auth Type</label></td>
+                <td><label id="authtype-label">@L["AuthTypeLabel"]</label></td>
                 <td aria-labelledby="authtype-label">
                     @foreach (AuthType type in Enum.GetValues<AuthType>())
                     {
@@ -54,14 +55,14 @@
                         var url = BuildUrl("auth", type == AuthType.Nonce ? "nonce" : "apppass");
                         <button type="button" class="btn btn-sm me-1 @(active ? "btn-primary" : "btn-outline-secondary")"
                             role="button" aria-pressed="@active" data-testid="@($"auth-{type.ToString().ToLower()}")"
-                            title="@($"Set Auth to {type}")" @onclick="() => SetAuth(type, url)">
-                            @type
+                            title="@L["SetAuthTo", GetAuthLabel(type)]" @onclick="() => SetAuth(type, url)">
+                            @GetAuthLabel(type)
                         </button>
                     }
                 </td>
             </tr>
             <tr data-testid="row-language">
-                <td><label id="language-label">Language</label></td>
+                <td><label id="language-label">@L["LanguageLabel"]</label></td>
                 <td aria-labelledby="language-label">
                     @foreach (Language lang in Enum.GetValues<Language>())
                     {
@@ -69,25 +70,25 @@
                         var url = BuildUrl("lang", lang == Language.Japanese ? "jp" : "en");
                         <button type="button" class="btn btn-sm me-1 @(active ? "btn-primary" : "btn-outline-secondary")"
                             role="button" aria-pressed="@active" data-testid="@($"lang-{lang.ToString().ToLower()}")"
-                            title="@($"Set Language to {lang}")" @onclick="() => SetLanguage(lang, url)">
-                            @lang
+                            title="@L["SetLanguageTo", GetLanguageLabel(lang)]" @onclick="() => SetLanguage(lang, url)">
+                            @GetLanguageLabel(lang)
                         </button>
                     }
                 </td>
             </tr>
             <tr data-testid="row-wpurl">
                 <td>
-                    <label for="wpurl-input">WordPress URL</label>
+                    <label for="wpurl-input">@L["WpUrlLabel"]</label>
                 </td>
                 <td>
                     <form @onsubmit="OnWpUrlSubmit" data-testid="wpurl-form">
                         <div class="input-group">
                             <input id="wpurl-input" class="form-control" placeholder="https://example.com" @bind="wpUrl"
                                 @bind:event="oninput" data-testid="wpurl-input" />
-                            <button type="submit" class="btn btn-primary" data-testid="wpurl-save">Save</button>
+                            <button type="submit" class="btn btn-primary" data-testid="wpurl-save">@L["SaveButton"]</button>
                         </div>
                         <div class="form-text">
-                            Value is applied only on <strong>Save</strong> (or pressing <kbd>Enter</kbd>).
+                            @((MarkupString)L["WpUrlHint"].Value)
                         </div>
                     </form>
                 </td>
@@ -98,21 +99,21 @@
     <!-- Quick Check -->
     <div class="card mt-4" data-testid="wpdi-card">
         <div class="card-body">
-            <h5 class="card-title mb-3">WPDI Quick Check</h5>
+            <h5 class="card-title mb-3">@L["QuickCheckTitle"]</h5>
             <div class="row g-2 align-items-center mb-2">
-                <div class="col-auto">Auth Mode:</div>
-                <div class="col-auto"><span class="badge bg-info" data-testid="wpdi-auth">@Flags.Auth</span></div>
+                <div class="col-auto">@L["QuickCheckAuthLabel"]</div>
+                <div class="col-auto"><span class="badge bg-info" data-testid="wpdi-auth">@GetAuthLabel(Flags.Auth)</span></div>
             </div>
             <div class="mb-2">
-                <strong>Status:</strong>
-                <span data-testid="wpdi-status">@(_checkStatus ?? "Idle")</span>
+                <strong>@L["StatusLabel"]</strong>
+                <span data-testid="wpdi-status">@(_checkStatus ?? L["IdleStatus"].Value)</span>
                 @if (_httpCode is not null)
                 {
                     <span class="text-muted" data-testid="wpdi-code"> (@_httpCode)</span>
                 }
                 @if (!string.IsNullOrWhiteSpace(_userName))
                 {
-                    <span class="ms-2" data-testid="wpdi-user">user: @_userName</span>
+                    <span class="ms-2" data-testid="wpdi-user">@L["UserLabel"] @_userName</span>
                 }
                 @if (!string.IsNullOrWhiteSpace(_error))
                 {
@@ -120,12 +121,12 @@
                 }
                 @if (_lastChecked is not null)
                 {
-                    <div class="text-muted small" data-testid="wpdi-last">last: @_lastChecked</div>
+                    <div class="text-muted small" data-testid="wpdi-last">@L["LastLabel"] @_lastChecked</div>
                 }
             </div>
             <button class="btn btn-outline-primary btn-sm" data-testid="wpdi-run" disabled="@_checking"
                 @onclick="RunQuickCheck">
-                @(_checking ? "Checking…" : "Run check")
+                @(_checking ? L["CheckingEllipsis"] : L["RunCheck"])
             </button>
         </div>
     </div>
@@ -134,51 +135,48 @@
 <!-- Auth Scenarios Lab -->
 <div class="card mt-4" data-testid="authlab-card">
     <div class="card-body">
-        <h5 class="card-title mb-3">Auth Scenarios Lab</h5>
+        <h5 class="card-title mb-3">@L["AuthLabTitle"]</h5>
 
         <div class="mb-2 text-muted small">
-            Use these controls to simulate / prepare tricky states for tests: missing/invalid App Password,
-            or cookie/nonce not ready (use the WP login link + your test fixtures to control cookies).
+            @((MarkupString)L["AuthLabDescription"].Value)
         </div>
 
         <div class="row g-2 align-items-end mb-2">
             <div class="col-sm-4">
-                <label for="authlab-user" class="form-label">AppPass Username</label>
+                <label for="authlab-user" class="form-label">@L["AppPassUsernameLabel"]</label>
                 <input id="authlab-user" class="form-control" @bind="_appUser" data-testid="authlab-user" />
             </div>
             <div class="col-sm-4">
-                <label for="authlab-pass" class="form-label">AppPass Password</label>
+                <label for="authlab-pass" class="form-label">@L["AppPassPasswordLabel"]</label>
                 <input id="authlab-pass" type="password" class="form-control" @bind="_appPass"
                     data-testid="authlab-pass" />
             </div>
             <div class="col-sm-4 d-flex gap-2">
                 <button class="btn btn-primary" data-testid="authlab-save-valid" @onclick="SaveValidAppPass"
-                    disabled="@(_saving)">Save AppPass</button>
+                    disabled="@(_saving)">@L["SaveAppPassButton"]</button>
                 <button class="btn btn-outline-danger" data-testid="authlab-save-invalid" @onclick="SaveInvalidAppPass"
-                    disabled="@(_saving)">Save Invalid</button>
+                    disabled="@(_saving)">@L["SaveInvalidButton"]</button>
                 <button class="btn btn-outline-secondary" data-testid="authlab-clear" @onclick="ClearAppPass"
-                    disabled="@(_saving)">Clear</button>
+                    disabled="@(_saving)">@L["ClearButton"]</button>
             </div>
         </div>
 
         <div class="d-flex flex-wrap gap-2 mb-2">
-            <button class="btn btn-outline-primary btn-sm" data-testid="authlab-open-login" @onclick="OpenWpLogin">Open
-                WP Login</button>
+            <button class="btn btn-outline-primary btn-sm" data-testid="authlab-open-login" @onclick="OpenWpLogin">@L["OpenWpLoginButton"]</button>
             <button class="btn btn-outline-secondary btn-sm" data-testid="authlab-open-admin"
-                @onclick="OpenWpAdmin">Open WP Admin</button>
+                @onclick="OpenWpAdmin">@L["OpenWpAdminButton"]</button>
             <button class="btn btn-outline-dark btn-sm" data-testid="authlab-rebuild"
-                @onclick="ForceRebuildClient">Force Rebuild Client</button>
+                @onclick="ForceRebuildClient">@L["ForceRebuildButton"]</button>
         </div>
 
         <div class="small">
-            <div>Creds present: <strong data-testid="authlab-creds-present">@(_credsPresent ? "yes" : "no")</strong>
+            <div>@L["CredsPresentLabel"] <strong data-testid="authlab-creds-present">@(_credsPresent ? L["Yes"] : L["No"])</strong>
                 @if (_credsPresent)
                 {
                     <span class="ms-2 text-muted" data-testid="authlab-creds-mask">(@_credsMask)</span>
                 }
             </div>
-            <div class="text-muted">Tip: For <em>nonce not ready</em> cases, clear cookies via your test fixture and
-                reload this page, then run the WPDI Quick Check above in <strong>Nonce</strong> mode.</div>
+            <div class="text-muted">@((MarkupString)L["AuthLabTip"].Value)</div>
             @if (!string.IsNullOrEmpty(_authlabStatus))
             {
                 <div class="mt-2" data-testid="authlab-status">@_authlabStatus</div>
@@ -225,7 +223,7 @@
         {
             var (u, p) = (creds.Value.Username ?? "", creds.Value.AppPassword ?? "");
             _appUser = string.IsNullOrEmpty(_appUser) ? u : _appUser;
-            _credsMask = string.IsNullOrEmpty(p) ? "(empty)" : (p.Length <= 4 ? new string('*', p.Length) : new string('*', p.Length - 4) + p[^4..]);
+            _credsMask = string.IsNullOrEmpty(p) ? L["EmptyMask"] : (p.Length <= 4 ? new string('*', p.Length) : new string('*', p.Length - 4) + p[^4..]);
         }
         else
         {
@@ -304,7 +302,7 @@
     private async Task RunQuickCheck()
     {
         _checking = true;
-        _checkStatus = "Checking";
+        _checkStatus = L["CheckingStatus"];
         _error = null; _userName = null; _httpCode = null;
         StateHasChanged();
 
@@ -318,7 +316,7 @@
                     || string.IsNullOrWhiteSpace(creds.Value.Username)
                     || string.IsNullOrWhiteSpace(creds.Value.AppPassword))
                 {
-                    _checkStatus = "Unauthorized";
+                    _checkStatus = L["UnauthorizedStatus"];
                     _httpCode = (int)HttpStatusCode.Unauthorized;
                     return;
                 }
@@ -326,42 +324,42 @@
 
             // Call the domain service (Option A). It uses our managed HttpClient + handlers.
             var me = await Api.GetCurrentUserAsync();
-            _checkStatus = "OK";
+            _checkStatus = L["OkStatus"];
             _userName = me?.Name ?? me?.Username;
         }
         catch (AuthError ae)
         {
             _httpCode = (int)ae.StatusCode;
-            _checkStatus = "Unauthorized";
+            _checkStatus = L["UnauthorizedStatus"];
             _error = ae.Message;
         }
         catch (RateLimited rl)
         {
             _httpCode = 429;
-            _checkStatus = "HTTP 429";
-            _error = rl.RetryAfter is { } ra ? $"Too many requests. Retry after {ra}." : "Too many requests.";
+            _checkStatus = string.Format(L["HttpStatus"].Value, 429);
+            _error = rl.RetryAfter is { } ra ? string.Format(L["TooManyRequestsWithRetry"].Value, ra) : L["TooManyRequests"].Value;
         }
         catch (TimeoutError te)
         {
-            _checkStatus = "Error";
+            _checkStatus = L["ErrorStatus"];
             _error = te.Message;
         }
         catch (TransientHttpError th)
         {
             _httpCode = th.StatusCode is { } sc ? (int)sc : null;
-            _checkStatus = th.StatusCode is { } sc2 ? $"HTTP {(int)sc2}" : "Error";
+            _checkStatus = th.StatusCode is { } sc2 ? string.Format(L["HttpStatus"].Value, (int)sc2) : L["ErrorStatus"].Value;
             _error = th.Message;
         }
         catch (UnexpectedHttpError uh)
         {
             _httpCode = (int)uh.StatusCode;
-            _checkStatus = $"HTTP {_httpCode}";
+            _checkStatus = string.Format(L["HttpStatus"].Value, _httpCode);
             _error = uh.Message;
         }
         catch (Exception ex)
         {
             // 5xx and raw transport may still bubble HttpRequestException from PolicyHandler tests → show generic Error
-            _checkStatus = "Error";
+            _checkStatus = L["ErrorStatus"];
             _error = ex.Message;
         }
         finally
@@ -379,11 +377,11 @@
         {
             if (string.IsNullOrWhiteSpace(_appUser) || string.IsNullOrWhiteSpace(_appPass))
             {
-                _authlabStatus = "Enter both username and password.";
+                _authlabStatus = L["AuthLabStatusMissingCreds"];
                 return;
             }
             await AppPassService.SetAsync(_appUser, _appPass);
-            _authlabStatus = "Saved App Password.";
+            _authlabStatus = L["AuthLabStatusSaved"];
             Api.SetAuthPreference(WordPressAuthPreference.AppPassword(_appUser, _appPass));
             await LoadCredsPreview();
             await RunQuickCheck();
@@ -398,12 +396,12 @@
         {
             if (string.IsNullOrWhiteSpace(_appUser) || string.IsNullOrWhiteSpace(_appPass))
             {
-                _authlabStatus = "Enter both username and password (we will store an intentionally wrong one).";
+                _authlabStatus = L["AuthLabStatusMissingInvalid"];
                 return;
             }
             var wrong = _appPass + "-wrong";
             await AppPassService.SetAsync(_appUser, wrong);
-            _authlabStatus = "Saved intentionally invalid App Password.";
+            _authlabStatus = L["AuthLabStatusSavedInvalid"];
             Api.SetAuthPreference(WordPressAuthPreference.AppPassword(_appUser, wrong));
             await LoadCredsPreview();
             await RunQuickCheck();
@@ -417,7 +415,7 @@
         try
         {
             await AppPassService.ClearAsync();
-            _authlabStatus = "Cleared stored App Password.";
+            _authlabStatus = L["AuthLabStatusCleared"];
             Api.SetAuthPreference(WordPressAuthPreference.None);
             await LoadCredsPreview();
             await RunQuickCheck();
@@ -444,4 +442,8 @@
     }
 
     public void Dispose() => Flags.OnChange -= OnFlagsChanged;
+
+    private string GetModeLabel(AppMode mode) => L[$"AppMode_{mode}"];
+    private string GetAuthLabel(AuthType type) => L[$"AuthType_{type}"];
+    private string GetLanguageLabel(Language lang) => L[$"Language_{lang}"];
 }

--- a/src/BlazorWP/Pages/ApprovedEmailDemo.razor
+++ b/src/BlazorWP/Pages/ApprovedEmailDemo.razor
@@ -3,20 +3,21 @@
 @using System.Net.Http.Json
 @using System.Text.Json
 @inject IWordPressApiService Api
+@inject IStringLocalizer<ApprovedEmailDemo> L
 
-<PageTitle>Approved Email Demo</PageTitle>
+<PageTitle>@L["Title"]</PageTitle>
 
-<h1>Approved Email List</h1>
+<h1>@L["Heading"]</h1>
 
 @if (client == null)
 {
-    <p>No WordPress endpoint verified. Visit <NavLink href="/">Home</NavLink> first.</p>
+    <p>@L["NoEndpointStart"] <NavLink href="/">@L["HomeLink"]</NavLink>@L["NoEndpointEnd"]</p>
 }
 else
 {
     <div class="mb-3 d-flex gap-2">
-        <input class="form-control" placeholder="email@example.com" @bind="newEmail" />
-        <button class="btn btn-primary" @onclick="AddEmailAsync">Add</button>
+        <input class="form-control" placeholder="@L["EmailPlaceholder"]" @bind="newEmail" />
+        <button class="btn btn-primary" @onclick="AddEmailAsync">@L["AddButton"]</button>
     </div>
     @if (!string.IsNullOrEmpty(status))
     {
@@ -24,18 +25,18 @@ else
     }
     @if (emails == null)
     {
-        <p><em>Loading...</em></p>
+        <p><em>@L["Loading"]</em></p>
     }
     else if (emails.Count == 0)
     {
-        <p>No approved emails found.</p>
+        <p>@L["NoEmails"]</p>
     }
     else
     {
         <table class="table table-sm">
             <thead>
                 <tr>
-                    <th>Email</th>
+                    <th>@L["EmailColumn"]</th>
                     <th></th>
                 </tr>
             </thead>
@@ -45,7 +46,7 @@ else
                     <tr>
                         <td>@e</td>
                         <td>
-                            <button class="btn btn-danger btn-sm" @onclick="() => RemoveEmailAsync(e)">Remove</button>
+                            <button class="btn btn-danger btn-sm" @onclick="() => RemoveEmailAsync(e)">@L["RemoveButton"]</button>
                         </td>
                     </tr>
                 }
@@ -83,7 +84,7 @@ else
         }
         catch (Exception ex)
         {
-            status = $"Error: {ex.Message}";
+            status = string.Format(L["ErrorMessage"].Value, ex.Message);
             emails = new();
         }
         await InvokeAsync(StateHasChanged);
@@ -102,7 +103,7 @@ else
         }
         catch (Exception ex)
         {
-            status = $"Error: {ex.Message}";
+            status = string.Format(L["ErrorMessage"].Value, ex.Message);
         }
     }
 
@@ -118,7 +119,7 @@ else
         }
         catch (Exception ex)
         {
-            status = $"Error: {ex.Message}";
+            status = string.Format(L["ErrorMessage"].Value, ex.Message);
         }
     }
 }

--- a/src/BlazorWP/Pages/DataStorage.razor
+++ b/src/BlazorWP/Pages/DataStorage.razor
@@ -1,31 +1,28 @@
 @page "/data-storage"
 @inject LocalStorageJsInterop StorageJs
+@inject IStringLocalizer<DataStorage> L
 
-<PageTitle>Data Storage</PageTitle>
+<PageTitle>@L["Title"]</PageTitle>
 
-<h1>Data Storage</h1>
+<h1>@L["Heading"]</h1>
 
-<p>
-    This page shows information stored in <code>localStorage</code> by this application. The
-    most important entry is <code>wpEndpoint</code> which caches the detected WordPress site
-    URL so you don't need to verify it each time.
-</p>
+<p>@((MarkupString)L["Description"].Value)</p>
 
 @if (items == null)
 {
-    <p><em>Loading...</em></p>
+    <p><em>@L["Loading"]</em></p>
 }
 else if (items.Count == 0)
 {
-    <p>No stored data found.</p>
+    <p>@L["NoData"]</p>
 }
 else
 {
     <table class="table">
         <thead>
             <tr>
-                <th>Key</th>
-                <th>Value</th>
+                <th>@L["KeyHeader"]</th>
+                <th>@L["ValueHeader"]</th>
                 <th></th>
             </tr>
         </thead>
@@ -36,7 +33,7 @@ else
                     <td>@item.Key</td>
                     <td class="text-break">@item.Value</td>
                     <td>
-                        <button class="btn btn-danger btn-sm" @onclick="() => DeleteItem(item.Key)">Delete</button>
+                        <button class="btn btn-danger btn-sm" @onclick="() => DeleteItem(item.Key)">@L["DeleteButton"]</button>
                     </td>
                 </tr>
             }

--- a/src/BlazorWP/Pages/Diagnostics.razor
+++ b/src/BlazorWP/Pages/Diagnostics.razor
@@ -1,10 +1,12 @@
 @page "/diagnostics"
-<PageTitle>Diagnostics</PageTitle>
-<h3>Diagnostics</h3>
+@inject IStringLocalizer<Diagnostics> L
+
+<PageTitle>@L["Title"]</PageTitle>
+<h3>@L["Heading"]</h3>
 
 <table class="table">
     <thead>
-        <tr><th>Key</th><th>Value</th></tr>
+        <tr><th>@L["KeyHeader"]</th><th>@L["ValueHeader"]</th></tr>
     </thead>
     <tbody>
         @foreach (var setting in _settings)

--- a/src/BlazorWP/Pages/IndexedDbDemo.razor
+++ b/src/BlazorWP/Pages/IndexedDbDemo.razor
@@ -1,25 +1,26 @@
 @page "/indexeddb-demo"
 @inject ILocalStore LocalStore
+@inject IStringLocalizer<IndexedDbDemo> L
 
-<PageTitle>IndexedDB Demo</PageTitle>
+<PageTitle>@L["Title"]</PageTitle>
 
-<h3>IndexedDB Demo – Notes</h3>
+<h3>@L["Heading"]</h3>
 
 <!-- Note entry form (for adding or editing) -->
 <div class="mb-3">
-    <label class="form-label"><strong>Name:</strong></label>
-    <input @bind="currentNote.Name" class="form-control" placeholder="Enter note name" />
+    <label class="form-label"><strong>@L["NameLabel"]</strong></label>
+    <input @bind="currentNote.Name" class="form-control" placeholder="@L["NamePlaceholder"]" />
 </div>
 <div class="mb-3">
-    <label class="form-label"><strong>Description:</strong></label>
-    <textarea @bind="currentNote.Description" class="form-control" placeholder="Enter description"></textarea>
+    <label class="form-label"><strong>@L["DescriptionLabel"]</strong></label>
+    <textarea @bind="currentNote.Description" class="form-control" placeholder="@L["DescriptionPlaceholder"]"></textarea>
 </div>
 <button class="btn btn-primary me-2" @onclick="SaveNote">
-    @if (isEditing) { <span>Update Note</span> } else { <span>Add Note</span> }
+    @if (isEditing) { <span>@L["UpdateButton"]</span> } else { <span>@L["AddButton"]</span> }
 </button>
 @if (isEditing)
 {
-    <button class="btn btn-secondary" @onclick="CancelEdit">Cancel</button>
+    <button class="btn btn-secondary" @onclick="CancelEdit">@L["CancelButton"]</button>
 }
 
 <hr />
@@ -27,16 +28,16 @@
 <!-- Notes list display -->
 @if (notes.Count == 0)
 {
-    <p><em>No notes available.</em></p>
+    <p><em>@L["NoNotes"]</em></p>
 }
 else
 {
     <table class="table align-middle">
         <thead>
             <tr>
-                <th>Name</th>
-                <th>Description</th>
-                <th style="width:150px;">Actions</th>
+                <th>@L["NameColumn"]</th>
+                <th>@L["DescriptionColumn"]</th>
+                <th style="width:150px;">@L["ActionsColumn"]</th>
             </tr>
         </thead>
         <tbody>
@@ -46,8 +47,8 @@ else
                 <td>@note.Name</td>
                 <td>@note.Description</td>
                 <td>
-                    <button class="btn btn-sm btn-outline-secondary me-1" @onclick="@(() => EditNote(note))">Edit</button>
-                    <button class="btn btn-sm btn-danger" @onclick="@(() => DeleteNote(note))">Delete</button>
+                    <button class="btn btn-sm btn-outline-secondary me-1" @onclick="@(() => EditNote(note))">@L["EditButton"]</button>
+                    <button class="btn btn-sm btn-danger" @onclick="@(() => DeleteNote(note))">@L["DeleteButton"]</button>
                 </td>
             </tr>
         }

--- a/src/BlazorWP/Pages/Media.razor
+++ b/src/BlazorWP/Pages/Media.razor
@@ -1,7 +1,10 @@
 @page "/media"
 @inject WpMediaJsInterop MediaJs
+@inject IStringLocalizer<Media> L
 
-    <h3 id="media-library-label" class="px-4 mb-2">Media Library</h3>
+<PageTitle>@L["Title"]</PageTitle>
+
+<h3 id="media-library-label" class="px-4 mb-2">@L["Heading"]</h3>
 
     <!-- overlay (no spinner any more) -->
     <div @ref="overlayEl" class="media-overlay"></div>

--- a/src/BlazorWP/Pages/PclDemo.razor
+++ b/src/BlazorWP/Pages/PclDemo.razor
@@ -3,14 +3,15 @@
 @inject IJSRuntime JS
 @inject AppPasswordService AppPasswordService
 @inject IWordPressApiService Api
+@inject IStringLocalizer<PclDemo> L
 
-<PageTitle>PCL Demo</PageTitle>
+<PageTitle>@L["Title"]</PageTitle>
 
-<h1>PCL Demo</h1>
+<h1>@L["Heading"]</h1>
 
 @if (client == null)
 {
-    <p>No WordPress endpoint verified. Visit <NavLink href="/">Home</NavLink> first.</p>
+    <p>@L["NoEndpointStart"] <NavLink href="/">@L["HomeLink"]</NavLink>@L["NoEndpointEnd"]</p>
 }
 else
 {
@@ -27,8 +28,8 @@ else
                 </h2>
                 <div id="@collapseId" class="accordion-collapse collapse">
                     <div class="accordion-body">
-                        <button class="btn btn-sm btn-primary" @onclick="() => InvokeGet(ep)">GET</button>
-                        <button class="btn btn-sm btn-secondary ms-2" @onclick="() => CopyCurl(ep)">Copy Curl</button>
+                        <button class="btn btn-sm btn-primary" @onclick="() => InvokeGet(ep)">@L["GetButton"]</button>
+                        <button class="btn btn-sm btn-secondary ms-2" @onclick="() => CopyCurl(ep)">@L["CopyCurlButton"]</button>
                         <span class="ms-2 small"><code>@GetCurlCommand(ep)</code></span>
                         @if (!string.IsNullOrEmpty(ep.Result))
                         {
@@ -67,19 +68,19 @@ else
 
         endpoints = new()
         {
-            new ApiEndpoint("Posts", "wp/v2/posts", async c => await c.Posts.GetAllAsync()),
-            new ApiEndpoint("Pages", "wp/v2/pages", async c => await c.Pages.GetAllAsync()),
-            new ApiEndpoint("Comments", "wp/v2/comments", async c => await c.Comments.GetAllAsync()),
-            new ApiEndpoint("Categories", "wp/v2/categories", async c => await c.Categories.GetAllAsync()),
-            new ApiEndpoint("Tags", "wp/v2/tags", async c => await c.Tags.GetAllAsync()),
-            new ApiEndpoint("Users", "wp/v2/users", async c => await c.Users.GetAllAsync()),
-            new ApiEndpoint("Media", "wp/v2/media", async c => await c.Media.GetAllAsync()),
-            new ApiEndpoint("Taxonomies", "wp/v2/taxonomies", async c => await c.Taxonomies.GetAllAsync()),
-            new ApiEndpoint("Post Types", "wp/v2/types", async c => await c.PostTypes.GetAllAsync()),
-            new ApiEndpoint("Post Statuses", "wp/v2/statuses", async c => await c.PostStatuses.GetAllAsync()),
-            // new ApiEndpoint("Settings", "wp/v2/settings", async c => await c.Settings.GetAsync()),
-            new ApiEndpoint("Plugins", "wp/v2/plugins", async c => await c.Plugins.GetAllAsync()),
-            new ApiEndpoint("Themes", "wp/v2/themes", async c => await c.Themes.GetAllAsync())
+            new ApiEndpoint(L["EndpointPosts"].Value, "wp/v2/posts", async c => await c.Posts.GetAllAsync()),
+            new ApiEndpoint(L["EndpointPages"].Value, "wp/v2/pages", async c => await c.Pages.GetAllAsync()),
+            new ApiEndpoint(L["EndpointComments"].Value, "wp/v2/comments", async c => await c.Comments.GetAllAsync()),
+            new ApiEndpoint(L["EndpointCategories"].Value, "wp/v2/categories", async c => await c.Categories.GetAllAsync()),
+            new ApiEndpoint(L["EndpointTags"].Value, "wp/v2/tags", async c => await c.Tags.GetAllAsync()),
+            new ApiEndpoint(L["EndpointUsers"].Value, "wp/v2/users", async c => await c.Users.GetAllAsync()),
+            new ApiEndpoint(L["EndpointMedia"].Value, "wp/v2/media", async c => await c.Media.GetAllAsync()),
+            new ApiEndpoint(L["EndpointTaxonomies"].Value, "wp/v2/taxonomies", async c => await c.Taxonomies.GetAllAsync()),
+            new ApiEndpoint(L["EndpointPostTypes"].Value, "wp/v2/types", async c => await c.PostTypes.GetAllAsync()),
+            new ApiEndpoint(L["EndpointPostStatuses"].Value, "wp/v2/statuses", async c => await c.PostStatuses.GetAllAsync()),
+            // new ApiEndpoint(L["EndpointSettings"].Value, "wp/v2/settings", async c => await c.Settings.GetAsync()),
+            new ApiEndpoint(L["EndpointPlugins"].Value, "wp/v2/plugins", async c => await c.Plugins.GetAllAsync()),
+            new ApiEndpoint(L["EndpointThemes"].Value, "wp/v2/themes", async c => await c.Themes.GetAllAsync())
         };
     }
 
@@ -104,7 +105,7 @@ else
         }
         catch (Exception ex)
         {
-            ep.Result = $"Error: {ex.Message}";
+            ep.Result = string.Format(L["ErrorMessage"].Value, ex.Message);
         }
         await InvokeAsync(StateHasChanged);
     }

--- a/src/BlazorWP/Pages/TestMemory.razor
+++ b/src/BlazorWP/Pages/TestMemory.razor
@@ -1,18 +1,21 @@
 @page "/test-memory"
 @inject BlazorWP.Data.ILocalStore LocalStore
+@inject IStringLocalizer<TestMemory> L
 
-<h3>Test Local Memory (Harness)</h3>
+<PageTitle>@L["Title"]</PageTitle>
+
+<h3>@L["Heading"]</h3>
 
 <input id="title" data-testid="title-input" @bind="title" />
 
-<button id="add" data-testid="btn-add" @onclick="Add">Add</button>
-<button id="put" data-testid="btn-put" @onclick="Put">Put</button>
-<button id="get" data-testid="btn-get" @onclick="GetById">GetById</button>
-<button id="list" data-testid="btn-list" @onclick="ListAll">List</button>
-<button id="delete" data-testid="btn-delete" @onclick="Delete">Delete</button>
+<button id="add" data-testid="btn-add" @onclick="Add">@L["AddButton"]</button>
+<button id="put" data-testid="btn-put" @onclick="Put">@L["PutButton"]</button>
+<button id="get" data-testid="btn-get" @onclick="GetById">@L["GetButton"]</button>
+<button id="list" data-testid="btn-list" @onclick="ListAll">@L["ListButton"]</button>
+<button id="delete" data-testid="btn-delete" @onclick="Delete">@L["DeleteButton"]</button>
 
 <!-- NEW: single button that triggers two concurrent adds with distinct payloads -->
-<button id="add-race" data-testid="btn-add-race" @onclick="AddRaceCombined">Add Race</button>
+<button id="add-race" data-testid="btn-add-race" @onclick="AddRaceCombined">@L["AddRaceButton"]</button>
 
 <p id="status" data-testid="status" role="status" aria-live="polite">@status</p>
 
@@ -43,34 +46,34 @@
     {
         var key = $"draft:{Guid.NewGuid():N}";
         await LocalStore.PutAsync(STORE, new Draft { id = key, Title = title }); // upsert acts as insert
-        status = $"Added {key}";
+        status = string.Format(L["StatusAdded"].Value, key);
     }
 
     private async Task Put()
     {
         const string key = "draft:1";
         await LocalStore.PutAsync(STORE, new Draft { id = key, Title = title }); // upsert fixed id
-        status = "Put/Upserted!";
+        status = L["StatusPut"].Value;
     }
 
     private async Task GetById()
     {
         const string key = "draft:1";
         var result = await LocalStore.GetByKeyAsync<Draft>(STORE, key);
-        status = result?.Title ?? "Not found";
+        status = result?.Title ?? L["StatusNotFound"].Value;
     }
 
     private async Task ListAll()
     {
         drafts = (await LocalStore.GetAllAsync<Draft>(STORE)).ToList();
-        status = $"Listed {drafts.Count} items";
+        status = string.Format(L["StatusListed"].Value, drafts.Count);
     }
 
     private async Task Delete()
     {
         const string key = "draft:1";
         await LocalStore.DeleteAsync(STORE, key);
-        status = "Deleted!";
+        status = L["StatusDeleted"].Value;
     }
 
     // --- NEW: deterministic internal "race" ---
@@ -79,8 +82,8 @@
     {
         // Fire two concurrent writes with distinct payloads.
         // Small stagger to encourage interleaving; ordering is irrelevant.
-        var t1 = AddWithPayloadAsync("Quick Alpha", 30);
-        var t2 = AddWithPayloadAsync("Quick Beta",  0);
+        var t1 = AddWithPayloadAsync(L["PayloadQuickAlpha"].Value, 30);
+        var t2 = AddWithPayloadAsync(L["PayloadQuickBeta"].Value,  0);
         await Task.WhenAll(t1, t2);
     }
 
@@ -91,6 +94,6 @@
 
         var key = $"draft:{Guid.NewGuid():N}";
         await LocalStore.PutAsync(STORE, new Draft { id = key, Title = payloadTitle });
-        status = $"Added {key}";
+        status = string.Format(L["StatusAdded"].Value, key);
     }
 }

--- a/src/BlazorWP/Pages/UploadPdf.razor
+++ b/src/BlazorWP/Pages/UploadPdf.razor
@@ -8,13 +8,14 @@
 @using System.Net.Http
 @inject UploadPdfJsInterop PdfJs
 @inject IWordPressApiService Api
+@inject IStringLocalizer<UploadPdf> L
 
-<PageTitle>Upload PDF</PageTitle>
+<PageTitle>@L["Title"]</PageTitle>
 
-<h1>Upload PDF</h1>
+<h1>@L["Heading"]</h1>
 @if (client == null)
 {
-    <p>No WordPress endpoint verified. Visit <NavLink href="/">Home</NavLink> first.</p>
+    <p>@L["NoEndpointStart"] <NavLink href="/">@L["HomeLink"]</NavLink>@L["NoEndpointEnd"]</p>
 }
 else
 {
@@ -22,7 +23,7 @@ else
         <InputFile id="file-input" class="form-control" accept="application/pdf" OnChange="OnFileSelected" />
     </div>
     <div class="d-flex align-items-center gap-2 mb-3">
-        <button class="btn btn-primary" @onclick="UploadAsync" disabled="@(_file == null)">Upload to WordPress</button>
+        <button class="btn btn-primary" @onclick="UploadAsync" disabled="@(_file == null)">@L["UploadButton"]</button>
         @if (!string.IsNullOrEmpty(status)) { <span>@status</span> }
     </div>
     @if (isUploading)
@@ -33,18 +34,18 @@ else
     }
     <canvas id="canvas" style="display:none;"></canvas>
     <div class="preview-wrapper">
-        <img id="preview" class="preview-image mb-3" alt="PDF preview" />
+        <img id="preview" class="preview-image mb-3" alt="@L["PreviewAlt"]" />
     </div>
     @if (wpSizes != null)
     {
         <table class="table table-sm">
             <thead>
                 <tr>
-                    <th>Size name</th>
-                    <th>Width (px)</th>
-                    <th>Height (px)</th>
-                    <th>Crop mode</th>
-                    <th>Notes</th>
+                    <th>@L["SizeNameColumn"]</th>
+                    <th>@L["WidthColumn"]</th>
+                    <th>@L["HeightColumn"]</th>
+                    <th>@L["CropModeColumn"]</th>
+                    <th>@L["NotesColumn"]</th>
                 </tr>
             </thead>
             <tbody>
@@ -110,11 +111,11 @@ else
 
         wpSizes = new()
         {
-            new("thumbnail", 150, 150, "hard (cover)", "Preview thumbnail"),
-            new("medium", ScaledWidth(300), ScaledHeight(300), "soft (max)", "Scaled preview"),
-            new("medium_large", ScaledWidth(768), ScaledHeight(768), "soft (max)", "Max width 768"),
-            new("large", ScaledWidth(1024), ScaledHeight(1024), "soft (max)", "Max width 1024"),
-            new("full", w, h, "n/a", "Full first page")
+            new("thumbnail", 150, 150, L["CropHardCover"].Value, L["NotePreviewThumbnail"].Value),
+            new("medium", ScaledWidth(300), ScaledHeight(300), L["CropSoftMax"].Value, L["NoteScaledPreview"].Value),
+            new("medium_large", ScaledWidth(768), ScaledHeight(768), L["CropSoftMax"].Value, L["NoteMaxWidth768"].Value),
+            new("large", ScaledWidth(1024), ScaledHeight(1024), L["CropSoftMax"].Value, L["NoteMaxWidth1024"].Value),
+            new("full", w, h, L["CropFull"].Value, L["NoteFullFirstPage"].Value)
         };
     }
 
@@ -204,12 +205,12 @@ else
 
             var resp = await httpClient!.PostAsync(endpoint, form);
             resp.EnsureSuccessStatusCode();
-            status = "Upload complete";
+            status = L["UploadComplete"].Value;
             uploadProgress = 100;
         }
         catch (Exception ex)
         {
-            status = $"Error: {ex.Message}";
+            status = string.Format(L["ErrorMessage"].Value, ex.Message);
         }
         finally { isUploading = false; }
     }

--- a/src/BlazorWP/Pages/WpMe.razor
+++ b/src/BlazorWP/Pages/WpMe.razor
@@ -2,14 +2,15 @@
 @using Editor.WordPress
 @inject IWordPressApiService Api
 @inject IConfiguration Config
+@inject IStringLocalizer<WpMe> L
 
-<PageTitle>WP /me</PageTitle>
+<PageTitle>@L["Title"]</PageTitle>
 
-<h1>WordPress /users/me</h1>
+<h1>@L["Heading"]</h1>
 
 @if (loading)
 {
-  <p><em>Loading…</em></p>
+  <p><em>@L["Loading"]</em></p>
 }
 else if (!string.IsNullOrEmpty(error))
 {
@@ -18,13 +19,13 @@ else if (!string.IsNullOrEmpty(error))
 else if (meId is not null)
 {
   <div data-testid="wp-me-ok">
-    <div><strong>id:</strong> @meId</div>
-    <div><strong>name:</strong> @meName</div>
+    <div><strong>@L["IdLabel"]</strong> @meId</div>
+    <div><strong>@L["NameLabel"]</strong> @meName</div>
   </div>
 }
 else
 {
-  <p>No data.</p>
+  <p>@L["NoData"]</p>
 }
 
 @code {
@@ -40,7 +41,7 @@ else
       var client = await Api.GetClientAsync(); // uses wpurl app flag
       if (client is null)
       {
-        error = "No WordPress endpoint configured (wpurl app flag missing).";
+        error = L["NoEndpointConfigured"].Value;
         return;
       }
 
@@ -50,7 +51,7 @@ else
     }
     catch (Exception ex)
     {
-      error = ex.Message;
+      error = string.Format(L["UnexpectedError"].Value, ex.Message);
     }
     finally
     {

--- a/src/BlazorWP/Resources/Pages/AppFlags.ja.resx
+++ b/src/BlazorWP/Resources/Pages/AppFlags.ja.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>アプリフラグ</value></data>
+  <data name="Heading" xml:space="preserve"><value>アプリケーション設定</value></data>
+  <data name="StateModeLabel" xml:space="preserve"><value>モード:</value></data>
+  <data name="StateAuthLabel" xml:space="preserve"><value>認証:</value></data>
+  <data name="StateLanguageLabel" xml:space="preserve"><value>言語:</value></data>
+  <data name="StateWpUrlLabel" xml:space="preserve"><value>WP URL:</value></data>
+  <data name="FeatureHeader" xml:space="preserve"><value>機能</value></data>
+  <data name="OptionsHeader" xml:space="preserve"><value>オプション</value></data>
+  <data name="AppModeLabel" xml:space="preserve"><value>アプリモード</value></data>
+  <data name="AuthTypeLabel" xml:space="preserve"><value>認証方式</value></data>
+  <data name="LanguageLabel" xml:space="preserve"><value>言語</value></data>
+  <data name="SetAppModeTo" xml:space="preserve"><value>アプリモードを {0} に設定</value></data>
+  <data name="SetAuthTo" xml:space="preserve"><value>認証方式を {0} に設定</value></data>
+  <data name="SetLanguageTo" xml:space="preserve"><value>言語を {0} に設定</value></data>
+  <data name="WpUrlLabel" xml:space="preserve"><value>WordPress URL</value></data>
+  <data name="SaveButton" xml:space="preserve"><value>保存</value></data>
+  <data name="WpUrlHint" xml:space="preserve"><value>値は&lt;strong&gt;保存&lt;/strong&gt;（または &lt;kbd&gt;Enter&lt;/kbd&gt; キー）でのみ適用されます。</value></data>
+  <data name="QuickCheckTitle" xml:space="preserve"><value>WPDI クイックチェック</value></data>
+  <data name="QuickCheckAuthLabel" xml:space="preserve"><value>認証モード:</value></data>
+  <data name="StatusLabel" xml:space="preserve"><value>状態:</value></data>
+  <data name="IdleStatus" xml:space="preserve"><value>待機中</value></data>
+  <data name="UserLabel" xml:space="preserve"><value>ユーザー:</value></data>
+  <data name="LastLabel" xml:space="preserve"><value>最終:</value></data>
+  <data name="CheckingEllipsis" xml:space="preserve"><value>チェック中…</value></data>
+  <data name="RunCheck" xml:space="preserve"><value>チェックを実行</value></data>
+  <data name="AuthLabTitle" xml:space="preserve"><value>認証シナリオ ラボ</value></data>
+  <data name="AuthLabDescription" xml:space="preserve"><value>テストで扱いにくい状態（アプリパスワードの未設定・無効、クッキー／ノンス未準備など）を再現・準備するための操作です。WP ログインリンクとテストフィクスチャを組み合わせてクッキーを制御してください。</value></data>
+  <data name="AppPassUsernameLabel" xml:space="preserve"><value>アプリパスワードのユーザー名</value></data>
+  <data name="AppPassPasswordLabel" xml:space="preserve"><value>アプリパスワード</value></data>
+  <data name="SaveAppPassButton" xml:space="preserve"><value>アプリパスを保存</value></data>
+  <data name="SaveInvalidButton" xml:space="preserve"><value>無効な情報を保存</value></data>
+  <data name="ClearButton" xml:space="preserve"><value>クリア</value></data>
+  <data name="OpenWpLoginButton" xml:space="preserve"><value>WP ログインを開く</value></data>
+  <data name="OpenWpAdminButton" xml:space="preserve"><value>WP 管理画面を開く</value></data>
+  <data name="ForceRebuildButton" xml:space="preserve"><value>クライアントを再構築</value></data>
+  <data name="CredsPresentLabel" xml:space="preserve"><value>資格情報あり:</value></data>
+  <data name="Yes" xml:space="preserve"><value>あり</value></data>
+  <data name="No" xml:space="preserve"><value>なし</value></data>
+  <data name="AuthLabTip" xml:space="preserve"><value>ヒント: &lt;em&gt;ノンス未準備&lt;/em&gt;のケースでは、テストフィクスチャでクッキーを削除してからこのページを再読み込みし、上の WPDI クイックチェックを&lt;strong&gt;ノンス&lt;/strong&gt;モードで実行してください。</value></data>
+  <data name="EmptyMask" xml:space="preserve"><value>(空)</value></data>
+  <data name="CheckingStatus" xml:space="preserve"><value>チェック中</value></data>
+  <data name="UnauthorizedStatus" xml:space="preserve"><value>認証失敗</value></data>
+  <data name="OkStatus" xml:space="preserve"><value>OK</value></data>
+  <data name="HttpStatus" xml:space="preserve"><value>HTTP {0}</value></data>
+  <data name="TooManyRequestsWithRetry" xml:space="preserve"><value>リクエストが多すぎます。{0} 後に再試行してください。</value></data>
+  <data name="TooManyRequests" xml:space="preserve"><value>リクエストが多すぎます。</value></data>
+  <data name="ErrorStatus" xml:space="preserve"><value>エラー</value></data>
+  <data name="AuthLabStatusMissingCreds" xml:space="preserve"><value>ユーザー名とパスワードを両方入力してください。</value></data>
+  <data name="AuthLabStatusSaved" xml:space="preserve"><value>アプリパスワードを保存しました。</value></data>
+  <data name="AuthLabStatusMissingInvalid" xml:space="preserve"><value>ユーザー名とパスワードを両方入力してください（意図的に誤った値を保存します）。</value></data>
+  <data name="AuthLabStatusSavedInvalid" xml:space="preserve"><value>意図的に無効なアプリパスワードを保存しました。</value></data>
+  <data name="AuthLabStatusCleared" xml:space="preserve"><value>保存されたアプリパスワードを消去しました。</value></data>
+  <data name="AppMode_Basic" xml:space="preserve"><value>Basic / 基本</value></data>
+  <data name="AppMode_Full" xml:space="preserve"><value>Full / フル</value></data>
+  <data name="AuthType_Nonce" xml:space="preserve"><value>Nonce</value></data>
+  <data name="AuthType_AppPass" xml:space="preserve"><value>アプリパスワード</value></data>
+  <data name="Language_English" xml:space="preserve"><value>English / 英語</value></data>
+  <data name="Language_Japanese" xml:space="preserve"><value>日本語</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/AppFlags.resx
+++ b/src/BlazorWP/Resources/Pages/AppFlags.resx
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>App Flags</value></data>
+  <data name="Heading" xml:space="preserve"><value>Application Flags</value></data>
+  <data name="StateModeLabel" xml:space="preserve"><value>Mode:</value></data>
+  <data name="StateAuthLabel" xml:space="preserve"><value>Auth:</value></data>
+  <data name="StateLanguageLabel" xml:space="preserve"><value>Language:</value></data>
+  <data name="StateWpUrlLabel" xml:space="preserve"><value>WP URL:</value></data>
+  <data name="FeatureHeader" xml:space="preserve"><value>Feature</value></data>
+  <data name="OptionsHeader" xml:space="preserve"><value>Options</value></data>
+  <data name="AppModeLabel" xml:space="preserve"><value>App Mode</value></data>
+  <data name="AuthTypeLabel" xml:space="preserve"><value>Auth Type</value></data>
+  <data name="LanguageLabel" xml:space="preserve"><value>Language</value></data>
+  <data name="SetAppModeTo" xml:space="preserve"><value>Set App Mode to {0}</value></data>
+  <data name="SetAuthTo" xml:space="preserve"><value>Set Auth to {0}</value></data>
+  <data name="SetLanguageTo" xml:space="preserve"><value>Set Language to {0}</value></data>
+  <data name="WpUrlLabel" xml:space="preserve"><value>WordPress URL</value></data>
+  <data name="SaveButton" xml:space="preserve"><value>Save</value></data>
+  <data name="WpUrlHint" xml:space="preserve"><value>Value is applied only on &lt;strong&gt;Save&lt;/strong&gt; (or pressing &lt;kbd&gt;Enter&lt;/kbd&gt;).</value></data>
+  <data name="QuickCheckTitle" xml:space="preserve"><value>WPDI Quick Check</value></data>
+  <data name="QuickCheckAuthLabel" xml:space="preserve"><value>Auth Mode:</value></data>
+  <data name="StatusLabel" xml:space="preserve"><value>Status:</value></data>
+  <data name="IdleStatus" xml:space="preserve"><value>Idle</value></data>
+  <data name="UserLabel" xml:space="preserve"><value>user:</value></data>
+  <data name="LastLabel" xml:space="preserve"><value>last:</value></data>
+  <data name="CheckingEllipsis" xml:space="preserve"><value>Checking…</value></data>
+  <data name="RunCheck" xml:space="preserve"><value>Run check</value></data>
+  <data name="AuthLabTitle" xml:space="preserve"><value>Auth Scenarios Lab</value></data>
+  <data name="AuthLabDescription" xml:space="preserve"><value>Use these controls to simulate or prepare tricky states for tests: missing or invalid App Password, or cookie/nonce not ready (use the WP login link plus your test fixtures to control cookies).</value></data>
+  <data name="AppPassUsernameLabel" xml:space="preserve"><value>AppPass Username</value></data>
+  <data name="AppPassPasswordLabel" xml:space="preserve"><value>AppPass Password</value></data>
+  <data name="SaveAppPassButton" xml:space="preserve"><value>Save AppPass</value></data>
+  <data name="SaveInvalidButton" xml:space="preserve"><value>Save Invalid</value></data>
+  <data name="ClearButton" xml:space="preserve"><value>Clear</value></data>
+  <data name="OpenWpLoginButton" xml:space="preserve"><value>Open WP Login</value></data>
+  <data name="OpenWpAdminButton" xml:space="preserve"><value>Open WP Admin</value></data>
+  <data name="ForceRebuildButton" xml:space="preserve"><value>Force Rebuild Client</value></data>
+  <data name="CredsPresentLabel" xml:space="preserve"><value>Creds present:</value></data>
+  <data name="Yes" xml:space="preserve"><value>Yes</value></data>
+  <data name="No" xml:space="preserve"><value>No</value></data>
+  <data name="AuthLabTip" xml:space="preserve"><value>Tip: For &lt;em&gt;nonce not ready&lt;/em&gt; cases, clear cookies via your test fixture and reload this page, then run the WPDI Quick Check above in &lt;strong&gt;Nonce&lt;/strong&gt; mode.</value></data>
+  <data name="EmptyMask" xml:space="preserve"><value>(empty)</value></data>
+  <data name="CheckingStatus" xml:space="preserve"><value>Checking</value></data>
+  <data name="UnauthorizedStatus" xml:space="preserve"><value>Unauthorized</value></data>
+  <data name="OkStatus" xml:space="preserve"><value>OK</value></data>
+  <data name="HttpStatus" xml:space="preserve"><value>HTTP {0}</value></data>
+  <data name="TooManyRequestsWithRetry" xml:space="preserve"><value>Too many requests. Retry after {0}.</value></data>
+  <data name="TooManyRequests" xml:space="preserve"><value>Too many requests.</value></data>
+  <data name="ErrorStatus" xml:space="preserve"><value>Error</value></data>
+  <data name="AuthLabStatusMissingCreds" xml:space="preserve"><value>Enter both username and password.</value></data>
+  <data name="AuthLabStatusSaved" xml:space="preserve"><value>Saved App Password.</value></data>
+  <data name="AuthLabStatusMissingInvalid" xml:space="preserve"><value>Enter both username and password (an intentionally wrong one will be stored).</value></data>
+  <data name="AuthLabStatusSavedInvalid" xml:space="preserve"><value>Saved intentionally invalid App Password.</value></data>
+  <data name="AuthLabStatusCleared" xml:space="preserve"><value>Cleared stored App Password.</value></data>
+  <data name="AppMode_Basic" xml:space="preserve"><value>Basic</value></data>
+  <data name="AppMode_Full" xml:space="preserve"><value>Full</value></data>
+  <data name="AuthType_Nonce" xml:space="preserve"><value>Nonce</value></data>
+  <data name="AuthType_AppPass" xml:space="preserve"><value>App Password</value></data>
+  <data name="Language_English" xml:space="preserve"><value>English</value></data>
+  <data name="Language_Japanese" xml:space="preserve"><value>Japanese</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/ApprovedEmailDemo.ja.resx
+++ b/src/BlazorWP/Resources/Pages/ApprovedEmailDemo.ja.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>承認済みメール デモ</value></data>
+  <data name="Heading" xml:space="preserve"><value>承認済みメール一覧</value></data>
+  <data name="NoEndpointStart" xml:space="preserve"><value>WordPress エンドポイントが確認されていません。まず</value></data>
+  <data name="HomeLink" xml:space="preserve"><value>ホーム</value></data>
+  <data name="NoEndpointEnd" xml:space="preserve"><value>を開いてください。</value></data>
+  <data name="EmailPlaceholder" xml:space="preserve"><value>email@example.com</value></data>
+  <data name="AddButton" xml:space="preserve"><value>追加</value></data>
+  <data name="Loading" xml:space="preserve"><value>読み込み中...</value></data>
+  <data name="NoEmails" xml:space="preserve"><value>承認済みメールは見つかりません。</value></data>
+  <data name="EmailColumn" xml:space="preserve"><value>メール</value></data>
+  <data name="RemoveButton" xml:space="preserve"><value>削除</value></data>
+  <data name="ErrorMessage" xml:space="preserve"><value>エラー: {0}</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/ApprovedEmailDemo.resx
+++ b/src/BlazorWP/Resources/Pages/ApprovedEmailDemo.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>Approved Email Demo</value></data>
+  <data name="Heading" xml:space="preserve"><value>Approved Email List</value></data>
+  <data name="NoEndpointStart" xml:space="preserve"><value>No WordPress endpoint verified. Visit </value></data>
+  <data name="HomeLink" xml:space="preserve"><value>Home</value></data>
+  <data name="NoEndpointEnd" xml:space="preserve"><value> first.</value></data>
+  <data name="EmailPlaceholder" xml:space="preserve"><value>email@example.com</value></data>
+  <data name="AddButton" xml:space="preserve"><value>Add</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading...</value></data>
+  <data name="NoEmails" xml:space="preserve"><value>No approved emails found.</value></data>
+  <data name="EmailColumn" xml:space="preserve"><value>Email</value></data>
+  <data name="RemoveButton" xml:space="preserve"><value>Remove</value></data>
+  <data name="ErrorMessage" xml:space="preserve"><value>Error: {0}</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/DataStorage.ja.resx
+++ b/src/BlazorWP/Resources/Pages/DataStorage.ja.resx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>データストレージ</value></data>
+  <data name="Heading" xml:space="preserve"><value>データストレージ</value></data>
+  <data name="Description" xml:space="preserve"><value>このページでは本アプリが &lt;code&gt;localStorage&lt;/code&gt; に保存している情報を表示します。特に重要なのは検出した WordPress サイトの URL を保持する &lt;code&gt;wpEndpoint&lt;/code&gt; で、毎回確認する必要がなくなります。</value></data>
+  <data name="Loading" xml:space="preserve"><value>読み込み中...</value></data>
+  <data name="NoData" xml:space="preserve"><value>保存されたデータはありません。</value></data>
+  <data name="KeyHeader" xml:space="preserve"><value>キー</value></data>
+  <data name="ValueHeader" xml:space="preserve"><value>値</value></data>
+  <data name="DeleteButton" xml:space="preserve"><value>削除</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/DataStorage.resx
+++ b/src/BlazorWP/Resources/Pages/DataStorage.resx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>Data Storage</value></data>
+  <data name="Heading" xml:space="preserve"><value>Data Storage</value></data>
+  <data name="Description" xml:space="preserve"><value>This page shows information stored in &lt;code&gt;localStorage&lt;/code&gt; by this application. The most important entry is &lt;code&gt;wpEndpoint&lt;/code&gt; which caches the detected WordPress site URL so you don't need to verify it each time.</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading...</value></data>
+  <data name="NoData" xml:space="preserve"><value>No stored data found.</value></data>
+  <data name="KeyHeader" xml:space="preserve"><value>Key</value></data>
+  <data name="ValueHeader" xml:space="preserve"><value>Value</value></data>
+  <data name="DeleteButton" xml:space="preserve"><value>Delete</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/Diagnostics.ja.resx
+++ b/src/BlazorWP/Resources/Pages/Diagnostics.ja.resx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>診断</value></data>
+  <data name="Heading" xml:space="preserve"><value>診断</value></data>
+  <data name="KeyHeader" xml:space="preserve"><value>キー</value></data>
+  <data name="ValueHeader" xml:space="preserve"><value>値</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/Diagnostics.resx
+++ b/src/BlazorWP/Resources/Pages/Diagnostics.resx
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>Diagnostics</value></data>
+  <data name="Heading" xml:space="preserve"><value>Diagnostics</value></data>
+  <data name="KeyHeader" xml:space="preserve"><value>Key</value></data>
+  <data name="ValueHeader" xml:space="preserve"><value>Value</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/IndexedDbDemo.ja.resx
+++ b/src/BlazorWP/Resources/Pages/IndexedDbDemo.ja.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>IndexedDB デモ</value></data>
+  <data name="Heading" xml:space="preserve"><value>IndexedDB デモ - ノート</value></data>
+  <data name="NameLabel" xml:space="preserve"><value>名前:</value></data>
+  <data name="NamePlaceholder" xml:space="preserve"><value>ノート名を入力</value></data>
+  <data name="DescriptionLabel" xml:space="preserve"><value>説明:</value></data>
+  <data name="DescriptionPlaceholder" xml:space="preserve"><value>説明を入力</value></data>
+  <data name="UpdateButton" xml:space="preserve"><value>ノートを更新</value></data>
+  <data name="AddButton" xml:space="preserve"><value>ノートを追加</value></data>
+  <data name="CancelButton" xml:space="preserve"><value>キャンセル</value></data>
+  <data name="NoNotes" xml:space="preserve"><value>ノートはありません。</value></data>
+  <data name="NameColumn" xml:space="preserve"><value>名前</value></data>
+  <data name="DescriptionColumn" xml:space="preserve"><value>説明</value></data>
+  <data name="ActionsColumn" xml:space="preserve"><value>操作</value></data>
+  <data name="EditButton" xml:space="preserve"><value>編集</value></data>
+  <data name="DeleteButton" xml:space="preserve"><value>削除</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/IndexedDbDemo.resx
+++ b/src/BlazorWP/Resources/Pages/IndexedDbDemo.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>IndexedDB Demo</value></data>
+  <data name="Heading" xml:space="preserve"><value>IndexedDB Demo – Notes</value></data>
+  <data name="NameLabel" xml:space="preserve"><value>Name:</value></data>
+  <data name="NamePlaceholder" xml:space="preserve"><value>Enter note name</value></data>
+  <data name="DescriptionLabel" xml:space="preserve"><value>Description:</value></data>
+  <data name="DescriptionPlaceholder" xml:space="preserve"><value>Enter description</value></data>
+  <data name="UpdateButton" xml:space="preserve"><value>Update Note</value></data>
+  <data name="AddButton" xml:space="preserve"><value>Add Note</value></data>
+  <data name="CancelButton" xml:space="preserve"><value>Cancel</value></data>
+  <data name="NoNotes" xml:space="preserve"><value>No notes available.</value></data>
+  <data name="NameColumn" xml:space="preserve"><value>Name</value></data>
+  <data name="DescriptionColumn" xml:space="preserve"><value>Description</value></data>
+  <data name="ActionsColumn" xml:space="preserve"><value>Actions</value></data>
+  <data name="EditButton" xml:space="preserve"><value>Edit</value></data>
+  <data name="DeleteButton" xml:space="preserve"><value>Delete</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/Media.ja.resx
+++ b/src/BlazorWP/Resources/Pages/Media.ja.resx
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>メディア</value></data>
+  <data name="Heading" xml:space="preserve"><value>メディアライブラリ</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/Media.resx
+++ b/src/BlazorWP/Resources/Pages/Media.resx
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>Media</value></data>
+  <data name="Heading" xml:space="preserve"><value>Media Library</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/PclDemo.ja.resx
+++ b/src/BlazorWP/Resources/Pages/PclDemo.ja.resx
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>PCL デモ</value></data>
+  <data name="Heading" xml:space="preserve"><value>PCL デモ</value></data>
+  <data name="NoEndpointStart" xml:space="preserve"><value>WordPress エンドポイントが確認されていません。まず</value></data>
+  <data name="HomeLink" xml:space="preserve"><value>ホーム</value></data>
+  <data name="NoEndpointEnd" xml:space="preserve"><value>を開いてください。</value></data>
+  <data name="GetButton" xml:space="preserve"><value>取得</value></data>
+  <data name="CopyCurlButton" xml:space="preserve"><value>cURL をコピー</value></data>
+  <data name="EndpointPosts" xml:space="preserve"><value>投稿</value></data>
+  <data name="EndpointPages" xml:space="preserve"><value>固定ページ</value></data>
+  <data name="EndpointComments" xml:space="preserve"><value>コメント</value></data>
+  <data name="EndpointCategories" xml:space="preserve"><value>カテゴリー</value></data>
+  <data name="EndpointTags" xml:space="preserve"><value>タグ</value></data>
+  <data name="EndpointUsers" xml:space="preserve"><value>ユーザー</value></data>
+  <data name="EndpointMedia" xml:space="preserve"><value>メディア</value></data>
+  <data name="EndpointTaxonomies" xml:space="preserve"><value>タクソノミー</value></data>
+  <data name="EndpointPostTypes" xml:space="preserve"><value>投稿タイプ</value></data>
+  <data name="EndpointPostStatuses" xml:space="preserve"><value>投稿ステータス</value></data>
+  <data name="EndpointPlugins" xml:space="preserve"><value>プラグイン</value></data>
+  <data name="EndpointThemes" xml:space="preserve"><value>テーマ</value></data>
+  <data name="ErrorMessage" xml:space="preserve"><value>エラー: {0}</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/PclDemo.resx
+++ b/src/BlazorWP/Resources/Pages/PclDemo.resx
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>PCL Demo</value></data>
+  <data name="Heading" xml:space="preserve"><value>PCL Demo</value></data>
+  <data name="NoEndpointStart" xml:space="preserve"><value>No WordPress endpoint verified. Visit </value></data>
+  <data name="HomeLink" xml:space="preserve"><value>Home</value></data>
+  <data name="NoEndpointEnd" xml:space="preserve"><value> first.</value></data>
+  <data name="GetButton" xml:space="preserve"><value>GET</value></data>
+  <data name="CopyCurlButton" xml:space="preserve"><value>Copy Curl</value></data>
+  <data name="EndpointPosts" xml:space="preserve"><value>Posts</value></data>
+  <data name="EndpointPages" xml:space="preserve"><value>Pages</value></data>
+  <data name="EndpointComments" xml:space="preserve"><value>Comments</value></data>
+  <data name="EndpointCategories" xml:space="preserve"><value>Categories</value></data>
+  <data name="EndpointTags" xml:space="preserve"><value>Tags</value></data>
+  <data name="EndpointUsers" xml:space="preserve"><value>Users</value></data>
+  <data name="EndpointMedia" xml:space="preserve"><value>Media</value></data>
+  <data name="EndpointTaxonomies" xml:space="preserve"><value>Taxonomies</value></data>
+  <data name="EndpointPostTypes" xml:space="preserve"><value>Post Types</value></data>
+  <data name="EndpointPostStatuses" xml:space="preserve"><value>Post Statuses</value></data>
+  <data name="EndpointPlugins" xml:space="preserve"><value>Plugins</value></data>
+  <data name="EndpointThemes" xml:space="preserve"><value>Themes</value></data>
+  <data name="ErrorMessage" xml:space="preserve"><value>Error: {0}</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/TestMemory.ja.resx
+++ b/src/BlazorWP/Resources/Pages/TestMemory.ja.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>メモリテスト</value></data>
+  <data name="Heading" xml:space="preserve"><value>ローカルメモリテスト（ハーネス）</value></data>
+  <data name="AddButton" xml:space="preserve"><value>追加</value></data>
+  <data name="PutButton" xml:space="preserve"><value>Put/更新</value></data>
+  <data name="GetButton" xml:space="preserve"><value>IDで取得</value></data>
+  <data name="ListButton" xml:space="preserve"><value>一覧</value></data>
+  <data name="DeleteButton" xml:space="preserve"><value>削除</value></data>
+  <data name="AddRaceButton" xml:space="preserve"><value>同時追加</value></data>
+  <data name="StatusAdded" xml:space="preserve"><value>{0} を追加しました</value></data>
+  <data name="StatusPut" xml:space="preserve"><value>Put/Upsert 完了！</value></data>
+  <data name="StatusNotFound" xml:space="preserve"><value>見つかりません</value></data>
+  <data name="StatusListed" xml:space="preserve"><value>{0} 件を一覧表示</value></data>
+  <data name="StatusDeleted" xml:space="preserve"><value>削除しました！</value></data>
+  <data name="PayloadQuickAlpha" xml:space="preserve"><value>クイック Alpha</value></data>
+  <data name="PayloadQuickBeta" xml:space="preserve"><value>クイック Beta</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/TestMemory.resx
+++ b/src/BlazorWP/Resources/Pages/TestMemory.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>Test Memory</value></data>
+  <data name="Heading" xml:space="preserve"><value>Test Local Memory (Harness)</value></data>
+  <data name="AddButton" xml:space="preserve"><value>Add</value></data>
+  <data name="PutButton" xml:space="preserve"><value>Put</value></data>
+  <data name="GetButton" xml:space="preserve"><value>GetById</value></data>
+  <data name="ListButton" xml:space="preserve"><value>List</value></data>
+  <data name="DeleteButton" xml:space="preserve"><value>Delete</value></data>
+  <data name="AddRaceButton" xml:space="preserve"><value>Add Race</value></data>
+  <data name="StatusAdded" xml:space="preserve"><value>Added {0}</value></data>
+  <data name="StatusPut" xml:space="preserve"><value>Put/Upserted!</value></data>
+  <data name="StatusNotFound" xml:space="preserve"><value>Not found</value></data>
+  <data name="StatusListed" xml:space="preserve"><value>Listed {0} items</value></data>
+  <data name="StatusDeleted" xml:space="preserve"><value>Deleted!</value></data>
+  <data name="PayloadQuickAlpha" xml:space="preserve"><value>Quick Alpha</value></data>
+  <data name="PayloadQuickBeta" xml:space="preserve"><value>Quick Beta</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/UploadPdf.ja.resx
+++ b/src/BlazorWP/Resources/Pages/UploadPdf.ja.resx
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>PDF アップロード</value></data>
+  <data name="Heading" xml:space="preserve"><value>PDF をアップロード</value></data>
+  <data name="NoEndpointStart" xml:space="preserve"><value>WordPress エンドポイントが確認されていません。まず</value></data>
+  <data name="HomeLink" xml:space="preserve"><value>ホーム</value></data>
+  <data name="NoEndpointEnd" xml:space="preserve"><value>を開いてください。</value></data>
+  <data name="UploadButton" xml:space="preserve"><value>WordPress にアップロード</value></data>
+  <data name="PreviewAlt" xml:space="preserve"><value>PDF プレビュー</value></data>
+  <data name="SizeNameColumn" xml:space="preserve"><value>サイズ名</value></data>
+  <data name="WidthColumn" xml:space="preserve"><value>幅 (px)</value></data>
+  <data name="HeightColumn" xml:space="preserve"><value>高さ (px)</value></data>
+  <data name="CropModeColumn" xml:space="preserve"><value>トリミング方式</value></data>
+  <data name="NotesColumn" xml:space="preserve"><value>メモ</value></data>
+  <data name="CropHardCover" xml:space="preserve"><value>ハード（カバー）</value></data>
+  <data name="NotePreviewThumbnail" xml:space="preserve"><value>サムネイルプレビュー</value></data>
+  <data name="CropSoftMax" xml:space="preserve"><value>ソフト（最大）</value></data>
+  <data name="NoteScaledPreview" xml:space="preserve"><value>縮小プレビュー</value></data>
+  <data name="NoteMaxWidth768" xml:space="preserve"><value>最大幅 768</value></data>
+  <data name="NoteMaxWidth1024" xml:space="preserve"><value>最大幅 1024</value></data>
+  <data name="CropFull" xml:space="preserve"><value>該当なし</value></data>
+  <data name="NoteFullFirstPage" xml:space="preserve"><value>1 ページ目（フル）</value></data>
+  <data name="UploadComplete" xml:space="preserve"><value>アップロードが完了しました</value></data>
+  <data name="ErrorMessage" xml:space="preserve"><value>エラー: {0}</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/UploadPdf.resx
+++ b/src/BlazorWP/Resources/Pages/UploadPdf.resx
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>Upload PDF</value></data>
+  <data name="Heading" xml:space="preserve"><value>Upload PDF</value></data>
+  <data name="NoEndpointStart" xml:space="preserve"><value>No WordPress endpoint verified. Visit </value></data>
+  <data name="HomeLink" xml:space="preserve"><value>Home</value></data>
+  <data name="NoEndpointEnd" xml:space="preserve"><value> first.</value></data>
+  <data name="UploadButton" xml:space="preserve"><value>Upload to WordPress</value></data>
+  <data name="PreviewAlt" xml:space="preserve"><value>PDF preview</value></data>
+  <data name="SizeNameColumn" xml:space="preserve"><value>Size name</value></data>
+  <data name="WidthColumn" xml:space="preserve"><value>Width (px)</value></data>
+  <data name="HeightColumn" xml:space="preserve"><value>Height (px)</value></data>
+  <data name="CropModeColumn" xml:space="preserve"><value>Crop mode</value></data>
+  <data name="NotesColumn" xml:space="preserve"><value>Notes</value></data>
+  <data name="CropHardCover" xml:space="preserve"><value>hard (cover)</value></data>
+  <data name="NotePreviewThumbnail" xml:space="preserve"><value>Preview thumbnail</value></data>
+  <data name="CropSoftMax" xml:space="preserve"><value>soft (max)</value></data>
+  <data name="NoteScaledPreview" xml:space="preserve"><value>Scaled preview</value></data>
+  <data name="NoteMaxWidth768" xml:space="preserve"><value>Max width 768</value></data>
+  <data name="NoteMaxWidth1024" xml:space="preserve"><value>Max width 1024</value></data>
+  <data name="CropFull" xml:space="preserve"><value>n/a</value></data>
+  <data name="NoteFullFirstPage" xml:space="preserve"><value>Full first page</value></data>
+  <data name="UploadComplete" xml:space="preserve"><value>Upload complete</value></data>
+  <data name="ErrorMessage" xml:space="preserve"><value>Error: {0}</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/WpMe.ja.resx
+++ b/src/BlazorWP/Resources/Pages/WpMe.ja.resx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>WP /me</value></data>
+  <data name="Heading" xml:space="preserve"><value>WordPress /users/me</value></data>
+  <data name="Loading" xml:space="preserve"><value>読み込み中…</value></data>
+  <data name="IdLabel" xml:space="preserve"><value>ID:</value></data>
+  <data name="NameLabel" xml:space="preserve"><value>名前:</value></data>
+  <data name="NoData" xml:space="preserve"><value>データがありません。</value></data>
+  <data name="NoEndpointConfigured" xml:space="preserve"><value>WordPress エンドポイントが設定されていません（wpurl フラグが未設定です）。</value></data>
+  <data name="UnexpectedError" xml:space="preserve"><value>エラー: {0}</value></data>
+</root>

--- a/src/BlazorWP/Resources/Pages/WpMe.resx
+++ b/src/BlazorWP/Resources/Pages/WpMe.resx
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="Title" xml:space="preserve"><value>WP /me</value></data>
+  <data name="Heading" xml:space="preserve"><value>WordPress /users/me</value></data>
+  <data name="Loading" xml:space="preserve"><value>Loading…</value></data>
+  <data name="IdLabel" xml:space="preserve"><value>id:</value></data>
+  <data name="NameLabel" xml:space="preserve"><value>name:</value></data>
+  <data name="NoData" xml:space="preserve"><value>No data.</value></data>
+  <data name="NoEndpointConfigured" xml:space="preserve"><value>No WordPress endpoint configured (wpurl app flag missing).</value></data>
+  <data name="UnexpectedError" xml:space="preserve"><value>Error: {0}</value></data>
+</root>


### PR DESCRIPTION
## Summary
- localize the App Flags page, wiring quick check and AuthLab UI elements through IStringLocalizer lookups
- convert the remaining non-Edit Razor pages (ApprovedEmailDemo, DataStorage, Diagnostics, IndexedDbDemo, Media, PclDemo, TestMemory, UploadPdf, and WpMe) to localized strings
- add English and Japanese resource files for each newly localized page

## Testing
- not run (dotnet unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d76b87cb088322adf8a047f9565515