### PR TITLE
Handle read-only edit mode after WordPress 403

### DIFF
--- a/src/BlazorWP/Pages/Edit.Lifecycle2.razor.cs
+++ b/src/BlazorWP/Pages/Edit.Lifecycle2.razor.cs
@@ -60,6 +60,12 @@ public partial class Edit
 
             await JS.InvokeVoidAsync("setTinyMediaSource", Flags.WpUrl);
         }
+
+        if (_applyReadOnlyPending)
+        {
+            _applyReadOnlyPending = false;
+            await JS.InvokeVoidAsync("BlazorBridge.setReadOnly", "articleEditor", _readOnly);
+        }
     }
     // ✅ Must be public AND [JSInvokable] to be called from JS
     [JSInvokable]

--- a/src/BlazorWP/Pages/Edit.razor
+++ b/src/BlazorWP/Pages/Edit.razor
@@ -19,7 +19,7 @@
         <EditNew Id="Id" OnNewPage="NewPageAsync" />
         <div class="mb-3 d-flex align-items-center">
             <label class="form-label me-2 mb-0 text-nowrap">Title</label>
-            <input class="form-control flex-grow-1 min-w-0" value="@Title" @oninput="HandleTitleInput" />
+            <input class="form-control flex-grow-1 min-w-0" value="@Title" @oninput="HandleTitleInput" disabled="@_readOnly" />
 
         </div>
         <div id="editorHost" class="editor-host">
@@ -28,7 +28,7 @@
         </div>
 
         <EditSave isDirty="_isDirty" Saving="_saving" Status="_status" OnSave="SaveAsync" OnFork="ForkAsync"
-            CanFork="@(Id is int)" Forking="_forking" />
+            CanFork="@(Id is int)" Forking="_forking" ReadOnly="@_readOnly" />
     </RadzenSplitterPane>
 </RadzenSplitter>
 <MediaPopup @ref="_mediaPopup" />

--- a/src/BlazorWP/Pages/EditSave.razor
+++ b/src/BlazorWP/Pages/EditSave.razor
@@ -1,6 +1,6 @@
 @* File: src/BlazorWP/Pages/EditSave.razor *@
 <div class="d-flex align-items-center gap-2 mb-3">
-    <button class="btn btn-success" @onclick="OnSave" disabled="@(!isDirty || Saving)">
+    <button class="btn btn-success" @onclick="OnSave" disabled="@(ReadOnly || !isDirty || Saving)">
         @(Saving ? "Saving…" : "Save")
     </button>
     <button class="btn btn-outline-secondary" @onclick="OnFork" disabled="@(!CanFork || Saving || Forking)">
@@ -14,6 +14,7 @@
 </div>
 
 @code {
+    [Parameter] public bool ReadOnly { get; set; }
     [Parameter] public bool isDirty { get; set; }
     [Parameter] public bool Saving { get; set; }
     [Parameter] public string? Status { get; set; }

--- a/src/BlazorWP/wwwroot/js/blazor-bridge.js
+++ b/src/BlazorWP/wwwroot/js/blazor-bridge.js
@@ -27,6 +27,15 @@ window.BlazorBridge = {
             ed.setDirty(!!dirty);      // TinyMCE 6+
         }
     },
+    setReadOnly(editorId, ro) {
+        const ed = editorId ? tinymce.get(editorId) : tinymce.activeEditor;
+        if (!ed) { console.warn('[BlazorBridge] editor not found:', editorId); return; }
+        const mode = ro ? 'readonly' : 'design';
+        if (ed.mode && typeof ed.mode.set === 'function') ed.mode.set(mode);
+        else if (typeof ed.setMode === 'function') ed.setMode(mode);
+        this._isReadOnly = !!ro;
+    },
+    isReadOnly() { return !!this._isReadOnly; },
     // Notify Blazor that a save was triggered, passing the HTML
     onSave(html) {
         // Use the stored DotNetObjectReference from init()

--- a/src/BlazorWP/wwwroot/js/tinyMceConfig.js
+++ b/src/BlazorWP/wwwroot/js/tinyMceConfig.js
@@ -10,6 +10,9 @@ window.myTinyMceConfig = {
   mediaSource: null,
   // TinyMCE "save" plugin callback (prevents default form submit)
   save_onsavecallback: function (editor) {
+    if (window.BlazorBridge?.isReadOnly && window.BlazorBridge.isReadOnly()) {
+      return;
+    }
     const html = editor.getContent({ format: 'html' });
     // Tell Blazor
     window.BlazorBridge?.onSave(html);


### PR DESCRIPTION
## Summary
- catch forbidden responses when loading edit context and fall back to view-only data while marking the editor as read-only
- propagate the read-only flag to the TinyMCE bridge and toolbar so the editor switches to view mode and ignores save attempts
- disable the page Save button when editing is not allowed and surface a status message explaining the read-only state

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8cdd9734083229d617578224e288d